### PR TITLE
feat: agentic memory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | 🤝 **会话级 Team 运行时** | `TeamMiddleware + TeamRuntime` 提供 `spawn_agent / send_message / get_agent_result / list_agents / close_agent` 协作能力 |
 | 🔍 **项目级 Hybrid RAG** | 作用域文档切分、Dense + BM25 + RRF、可选 FlashRank Rerank、邻域 Chunk 扩展、结构化证据回传 |
 | 💾 **可持久化向量存储** | `AGENT_VECTORSTORE_BACKEND=auto` 优先使用 Chroma，本地不可用时自动回退 `InMemoryVectorStore` |
-| 🧠 **上下文治理与记忆** | `SqliteSaver` 会话记忆、自动压缩摘要、项目级长期记忆（episodic / semantic / procedural） |
+| 🧠 **上下文治理与记忆** | `SqliteSaver` 会话记忆、自动压缩摘要、异步 Agentic 长期记忆（episode / user memory / knowledge memory / reconcile） |
 | 🛠️ **运行时工具集** | 文档检索/阅读、学术搜索、联网搜索、技能调用、计划/Todo、Team 工具按运行时装配 |
 | 📝 **可插拔技能体系** | 内置 `summary` / `critical_reading` / `method_compare` / `translation` / `mindmap` / `agentic_search` 六类技能 |
 | 🗂️ **项目化工作区** | 多项目隔离、文档绑定、独立会话、会话消息与线程 ID 持久化 |
@@ -151,16 +151,19 @@ flowchart TB
     C --> D[auto_compact_messages]
     D --> E[LLM 摘要 + 事实锚点]
     E --> F[(session_compact_memory)]
-    G[当前用户问题] --> H[search_project_memory_items]
-    H --> I[episodic<br/>TTL 30 天]
-    H --> J[semantic<br/>长期保留]
-    H --> K[procedural<br/>TTL 90 天]
-    I --> L[词项匹配 + 时效分数]
-    J --> L
-    K --> L
-    F --> M[build_hinted_prompt]
-    L --> M
-    M --> N[注入 execute_turn_core]
+    A --> G[对话完成]
+    G --> H[(memory_episodes)]
+    H --> I[async memory_writer]
+    I --> J[extract candidates]
+    J --> K[reconcile<br/>ADD / UPDATE / DELETE / NONE / SUPERSEDE]
+    K --> L[(memory_items + evidence)]
+    M[当前用户问题] --> N[query_long_term_memory]
+    N --> O[user_memory<br/>policy channel]
+    N --> P[knowledge_memory<br/>context channel]
+    F --> Q[build_hinted_prompt]
+    O --> Q
+    P --> Q
+    Q --> R[注入 execute_turn_core]
 ```
 
 ---

--- a/README_EN.md
+++ b/README_EN.md
@@ -39,7 +39,7 @@
 | 🤝 **Session-Scoped Team Runtime** | `TeamMiddleware + TeamRuntime` expose `spawn_agent / send_message / get_agent_result / list_agents / close_agent` for lightweight collaboration |
 | 🔍 **Project-Scoped Hybrid RAG** | Scoped document chunking, Dense + BM25 + RRF, optional FlashRank rerank, neighbour chunk expansion, and structured evidence payloads |
 | 💾 **Persistent Vector Store with Fallback** | `AGENT_VECTORSTORE_BACKEND=auto` prefers local Chroma persistence and falls back to `InMemoryVectorStore` when unavailable |
-| 🧠 **Context Governance & Memory** | `SqliteSaver` session memory, auto-compacted summaries, and project-level long-term memory (`episodic / semantic / procedural`) |
+| 🧠 **Context Governance & Memory** | `SqliteSaver` session memory, auto-compacted summaries, and async agentic long-term memory (`episode / user memory / knowledge memory / reconcile`) |
 | 🛠️ **Runtime Tooling** | Document retrieval/reading, academic search, web search, skills, plan/Todo utilities, and Team tools are assembled at runtime |
 | 📝 **Pluggable Skills** | Six packaged skills: `summary`, `critical_reading`, `method_compare`, `translation`, `mindmap`, and `agentic_search` |
 | 🗂️ **Project Workspaces** | Multi-project isolation, document binding, independent sessions, and persisted thread/session state |
@@ -145,16 +145,19 @@ flowchart TB
     C --> D[auto_compact_messages]
     D --> E[LLM summary + fact anchors]
     E --> F[(session_compact_memory)]
-    G[Current user query] --> H[search_project_memory_items]
-    H --> I[episodic<br/>TTL 30 days]
-    H --> J[semantic<br/>retained]
-    H --> K[procedural<br/>TTL 90 days]
-    I --> L[term overlap + recency score]
-    J --> L
-    K --> L
-    F --> M[build_hinted_prompt]
-    L --> M
-    M --> N[injected into execute_turn_core]
+    A --> G[Turn completed]
+    G --> H[(memory_episodes)]
+    H --> I[async memory_writer]
+    I --> J[extract candidates]
+    J --> K[reconcile<br/>ADD / UPDATE / DELETE / NONE / SUPERSEDE]
+    K --> L[(memory_items + evidence)]
+    M[Current user query] --> N[query_long_term_memory]
+    N --> O[user_memory<br/>policy channel]
+    N --> P[knowledge_memory<br/>context channel]
+    F --> Q[build_hinted_prompt]
+    O --> Q
+    P --> Q
+    Q --> R[injected into execute_turn_core]
 ```
 
 ---

--- a/agent/adapters/sqlite/project_repository.py
+++ b/agent/adapters/sqlite/project_repository.py
@@ -133,7 +133,39 @@ def ensure_projects_tables(db_name: str = "./database.sqlite") -> None:
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             last_accessed_at TEXT,
-            expires_at TEXT DEFAULT ''
+            expires_at TEXT DEFAULT '',
+            canonical_text TEXT DEFAULT '',
+            dedup_key TEXT DEFAULT '',
+            status TEXT DEFAULT 'active',
+            confidence REAL DEFAULT 0,
+            source_episode_uid TEXT DEFAULT '',
+            evidence_json TEXT DEFAULT '[]',
+            superseded_by TEXT DEFAULT ''
+        )
+    """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_episodes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            episode_uid TEXT UNIQUE NOT NULL,
+            uuid TEXT NOT NULL,
+            project_uid TEXT NOT NULL,
+            session_uid TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            answer TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+    """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_item_evidence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_uid TEXT NOT NULL,
+            episode_uid TEXT NOT NULL,
+            evidence_json TEXT DEFAULT '{}',
+            created_at TEXT NOT NULL
         )
     """
     )
@@ -141,6 +173,20 @@ def ensure_projects_tables(db_name: str = "./database.sqlite") -> None:
     memory_columns = {row[1] for row in cursor.fetchall()}
     if "expires_at" not in memory_columns:
         cursor.execute("ALTER TABLE memory_items ADD COLUMN expires_at TEXT DEFAULT ''")
+    if "canonical_text" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN canonical_text TEXT DEFAULT ''")
+    if "dedup_key" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN dedup_key TEXT DEFAULT ''")
+    if "status" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN status TEXT DEFAULT 'active'")
+    if "confidence" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN confidence REAL DEFAULT 0")
+    if "source_episode_uid" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN source_episode_uid TEXT DEFAULT ''")
+    if "evidence_json" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN evidence_json TEXT DEFAULT '[]'")
+    if "superseded_by" not in memory_columns:
+        cursor.execute("ALTER TABLE memory_items ADD COLUMN superseded_by TEXT DEFAULT ''")
 
     cursor.execute("PRAGMA table_info(project_sessions)")
     session_columns = {row[1] for row in cursor.fetchall()}
@@ -176,6 +222,21 @@ def ensure_projects_tables(db_name: str = "./database.sqlite") -> None:
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_items_expire ON memory_items(expires_at)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_episodes_scope ON memory_episodes(uuid, project_uid, session_uid, created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_active_lookup ON memory_items(uuid, project_uid, status, updated_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key ON memory_items(dedup_key)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_episode ON memory_items(source_episode_uid, updated_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_item_evidence_memory ON memory_item_evidence(memory_uid, episode_uid)"
     )
 
     cursor.execute(

--- a/agent/application/agent_center/controller.py
+++ b/agent/application/agent_center/controller.py
@@ -2,6 +2,7 @@ from typing import Any
 
 PROMPT_LAYOUT_VERSION = "CTXv1"
 PROMPT_INVENTORY_TAG = "I"
+PROMPT_POLICY_TAG = "P"
 PROMPT_SUMMARY_TAG = "S"
 PROMPT_MEMORY_TAG = "M"
 PROMPT_LANGUAGE_TAG = "L"
@@ -74,14 +75,25 @@ def build_hinted_prompt(
         prompt_with_language=str(prompt_with_language or base_prompt),
     )
 
-    long_term_memories = search_project_memory_items_fn(
+    user_memories = search_project_memory_items_fn(
+        uuid=user_uuid,
+        project_uid=project_uid,
+        query="",
+        memory_type="user_memory",
+        status="active",
+        limit=max(1, min(3, memory_limit)),
+    )
+    knowledge_memories = search_project_memory_items_fn(
         uuid=user_uuid,
         project_uid=project_uid,
         query=base_prompt,
+        memory_type="knowledge_memory",
+        status="active",
         limit=memory_limit,
     )
     compact_summary_text = _collapse_inline_text(compact_summary, limit=1400)
-    memory_text = _serialize_memory_items(long_term_memories, max_chars=1600)
+    policy_text = _serialize_memory_items(user_memories, max_chars=480)
+    memory_text = _serialize_memory_items(knowledge_memories, max_chars=1600)
     language_text = _normalize_language_note(language_note)
     inventory_line = _build_inventory_line(
         system_prompt_id=system_prompt_id,
@@ -93,6 +105,7 @@ def build_hinted_prompt(
         [
             PROMPT_LAYOUT_VERSION,
             inventory_line,
+            f"{PROMPT_POLICY_TAG}:{policy_text or '-'}",
             f"{PROMPT_SUMMARY_TAG}:{compact_summary_text or '-'}",
             f"{PROMPT_MEMORY_TAG}:{memory_text or '-'}",
             f"{PROMPT_LANGUAGE_TAG}:{language_text or '-'}",

--- a/agent/application/agent_center/memory.py
+++ b/agent/application/agent_center/memory.py
@@ -1,5 +1,30 @@
-from agent.memory.policy import classify_turn_memory_type, ttl_for_memory_type
-from agent.memory.store import upsert_project_memory_item
+from uuid import uuid4
+
+from agent.memory.store import save_project_memory_episode
+from utils.task_queue import TaskStatus, create_task, enqueue_task, update_task_status
+from utils.tasks import task_memory_writer
+
+
+def _enqueue_memory_writer(*, episode_uid: str, user_uuid: str, db_name: str) -> None:
+    normalized_episode_uid = str(episode_uid or "").strip()
+    if not normalized_episode_uid:
+        return
+    task_id = f"memory-{uuid4().hex}"
+    create_task(task_id, normalized_episode_uid, "memory_writer", db_name=db_name)
+    enqueue_result = enqueue_task(
+        task_memory_writer,
+        task_id,
+        normalized_episode_uid,
+        user_uuid,
+        db_name=db_name,
+    )
+    if isinstance(enqueue_result, dict) and enqueue_result.get("mode") == "queued":
+        update_task_status(
+            task_id,
+            TaskStatus.QUEUED,
+            job_id=str(enqueue_result.get("job_id") or ""),
+            db_name=db_name,
+        )
 
 
 def persist_turn_memory(
@@ -10,24 +35,17 @@ def persist_turn_memory(
     prompt: str,
     answer: str,
 ) -> None:
+    db_name = "./database.sqlite"
     prompt_text = str(prompt or "").strip()
     answer_text = str(answer or "").strip()
     if not prompt_text or not answer_text:
         return
-    max_len = 1200
-    memory_content = f"Q: {prompt_text}\nA: {answer_text}"
-    if len(memory_content) > max_len:
-        memory_content = memory_content[:max_len] + "..."
-    memory_type = classify_turn_memory_type(prompt_text, answer_text)
-    expires_at = ttl_for_memory_type(memory_type)
-    upsert_project_memory_item(
+    episode_uid = save_project_memory_episode(
         uuid=user_uuid,
         project_uid=project_uid,
         session_uid=session_uid,
-        memory_type=memory_type,
-        title=prompt_text[:80],
-        content=memory_content,
-        source_prompt=prompt_text[:500],
-        source_answer=answer_text[:800],
-        expires_at=expires_at,
+        prompt=prompt_text,
+        answer=answer_text,
+        db_name=db_name,
     )
+    _enqueue_memory_writer(episode_uid=episode_uid, user_uuid=user_uuid, db_name=db_name)

--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -1,4 +1,6 @@
+from .extraction import extract_memory_candidates
 from .policy import classify_turn_memory_type, inject_long_term_memory, ttl_for_memory_type
+from .reconcile import apply_memory_candidates
 from .repository import (
     ensure_memory_tables,
     get_project_memory_episode,
@@ -8,6 +10,7 @@ from .repository import (
     save_project_memory_episode,
     save_project_session_compact_memory,
     touch_memory_items,
+    update_memory_item_status,
     upsert_project_memory_item,
 )
 from .service import search_project_memory_items
@@ -17,6 +20,8 @@ __all__ = [
     "classify_turn_memory_type",
     "ttl_for_memory_type",
     "inject_long_term_memory",
+    "extract_memory_candidates",
+    "apply_memory_candidates",
     "ensure_memory_tables",
     "save_project_memory_episode",
     "get_project_memory_episode",
@@ -24,6 +29,7 @@ __all__ = [
     "get_project_session_compact_memory",
     "save_project_session_compact_memory",
     "upsert_project_memory_item",
+    "update_memory_item_status",
     "list_project_memory_items",
     "touch_memory_items",
     "search_project_memory_items",

--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -1,8 +1,11 @@
 from .policy import classify_turn_memory_type, inject_long_term_memory, ttl_for_memory_type
 from .repository import (
     ensure_memory_tables,
+    get_project_memory_episode,
     get_project_session_compact_memory,
+    list_project_memory_episodes,
     list_project_memory_items,
+    save_project_memory_episode,
     save_project_session_compact_memory,
     touch_memory_items,
     upsert_project_memory_item,
@@ -15,6 +18,9 @@ __all__ = [
     "ttl_for_memory_type",
     "inject_long_term_memory",
     "ensure_memory_tables",
+    "save_project_memory_episode",
+    "get_project_memory_episode",
+    "list_project_memory_episodes",
     "get_project_session_compact_memory",
     "save_project_session_compact_memory",
     "upsert_project_memory_item",

--- a/agent/memory/extraction.py
+++ b/agent/memory/extraction.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import sqlite3
 from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent.llm_provider import build_openai_compatible_chat_model
+
+logger = logging.getLogger(__name__)
 
 VALID_MEMORY_ACTIONS = {"ADD", "UPDATE", "DELETE", "NONE", "SUPERSEDE"}
 VALID_MEMORY_TYPES = {"user_memory", "knowledge_memory"}
@@ -22,6 +25,12 @@ Rules:
 - Extract only durable memory. Ignore small talk, transient requests, and one-off acknowledgements.
 - `user_memory` is for stable user preferences, response instructions, and long-lived constraints.
 - `knowledge_memory` is for durable project or paper facts worth recalling later.
+- The stored memory must be a short declarative fragment statement, not a transcript.
+- Do not store memory as Q/A, dialogue turns, speaker-prefixed text, or copied conversational exchange.
+- Good examples:
+  - `user prefers concise answers`
+  - `user codes mostly in golang`
+  - `project Apollo deadline moved to Apr 30`
 - Every candidate must include:
   - `action`: one of ADD, UPDATE, DELETE, NONE, SUPERSEDE
   - `memory_type`: `user_memory` or `knowledge_memory`
@@ -126,6 +135,19 @@ class MemoryCandidate(BaseModel):
             return 1.0
         return normalized
 
+    @field_validator("evidence", mode="before")
+    @classmethod
+    def _normalize_evidence_field(cls, value: Any) -> list[dict[str, Any]]:
+        if not isinstance(value, list):
+            return []
+        normalized: list[dict[str, Any]] = []
+        for item in value:
+            if isinstance(item, dict):
+                normalized.append(item)
+            elif isinstance(item, str) and item.strip():
+                normalized.append({"quote": item.strip()})
+        return normalized
+
 
 class MemoryExtractionResult(BaseModel):
     candidates: list[MemoryCandidate] = Field(default_factory=list)
@@ -158,6 +180,39 @@ def _extract_json_object(raw_text: str) -> str:
     if start < 0 or end < start:
         raise ValueError("memory extractor did not return a JSON object")
     return text[start : end + 1]
+
+
+def _coerce_extraction_payload(parsed: Any) -> MemoryExtractionResult:
+    if isinstance(parsed, dict) and isinstance(parsed.get("candidates"), list):
+        return MemoryExtractionResult.model_validate(parsed)
+    if isinstance(parsed, list):
+        return MemoryExtractionResult.model_validate({"candidates": parsed})
+    if isinstance(parsed, dict) and (
+        "memory_type" in parsed or "canonical_text" in parsed or "content" in parsed
+    ):
+        return MemoryExtractionResult.model_validate({"candidates": [parsed]})
+    raise ValueError("memory extractor payload does not contain candidates")
+
+
+def _parse_extraction_result(raw_text: str) -> MemoryExtractionResult:
+    text = str(raw_text or "").strip()
+    if not text:
+        return MemoryExtractionResult(candidates=[])
+    decoder = json.JSONDecoder()
+    candidate_positions = [index for index, char in enumerate(text) if char in "{["]
+    for index in candidate_positions:
+        try:
+            parsed, _end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        try:
+            return _coerce_extraction_payload(parsed)
+        except Exception:
+            continue
+    try:
+        return MemoryExtractionResult.model_validate_json(_extract_json_object(text))
+    except ValidationError as exc:
+        raise ValueError(f"memory extractor returned invalid payload: {exc}") from exc
 
 
 def _normalize_evidence(
@@ -219,6 +274,7 @@ def extract_memory_candidates(
     recent_episodes: list[dict[str, Any]],
     active_memories: list[dict[str, Any]],
     user_uuid: str,
+    db_name: str = "./database.sqlite",
 ) -> list[dict[str, Any]]:
     prompt = str(episode.get("prompt") or "").strip()
     answer = str(episode.get("answer") or "").strip()
@@ -226,13 +282,13 @@ def extract_memory_candidates(
     if not prompt or not answer or not episode_uid:
         return []
 
-    api_key = read_api_key_for_user(uuid=user_uuid)
+    api_key = read_api_key_for_user(uuid=user_uuid, db_name=db_name)
     if not api_key:
         raise ValueError("memory extraction requires a configured API key")
-    model_name = read_model_name_for_user(uuid=user_uuid)
+    model_name = read_model_name_for_user(uuid=user_uuid, db_name=db_name)
     if not model_name:
         raise ValueError("memory extraction requires a configured model name")
-    base_url = read_base_url_for_user(uuid=user_uuid)
+    base_url = read_base_url_for_user(uuid=user_uuid, db_name=db_name)
 
     llm = create_chat_model(
         api_key=api_key,
@@ -255,9 +311,10 @@ def extract_memory_candidates(
     )
     result_text = _content_to_text(getattr(result, "content", result))
     try:
-        parsed = MemoryExtractionResult.model_validate_json(_extract_json_object(result_text))
-    except ValidationError as exc:
-        raise ValueError(f"memory extractor returned invalid payload: {exc}") from exc
+        parsed = _parse_extraction_result(result_text)
+    except Exception as exc:
+        logger.error("memory extractor raw response: %s", result_text)
+        raise
 
     candidates: list[dict[str, Any]] = []
     for candidate in parsed.candidates:

--- a/agent/memory/extraction.py
+++ b/agent/memory/extraction.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MemoryCandidate(BaseModel):
+    action: str = Field(default="ADD")
+    memory_type: str
+    title: str
+    content: str
+    canonical_text: str
+    dedup_key: str
+    confidence: float = 0.0
+    source_episode_uid: str
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def _build_user_memory_candidate(episode: dict[str, Any]) -> MemoryCandidate:
+    prompt = str(episode.get("prompt") or "").strip()
+    answer = str(episode.get("answer") or "").strip()
+    episode_uid = str(episode.get("episode_uid") or "").strip()
+    canonical = prompt.replace("请记住", "").strip("，,。. ")
+    return MemoryCandidate(
+        memory_type="user_memory",
+        title=prompt[:80] or "用户偏好",
+        content=f"{prompt}\n{answer}".strip(),
+        canonical_text=canonical or prompt,
+        dedup_key="user:response_preferences",
+        confidence=0.85,
+        source_episode_uid=episode_uid,
+        evidence=[{"episode_uid": episode_uid, "quote": prompt}],
+    )
+
+
+def _build_knowledge_memory_candidate(episode: dict[str, Any]) -> MemoryCandidate:
+    prompt = str(episode.get("prompt") or "").strip()
+    answer = str(episode.get("answer") or "").strip()
+    episode_uid = str(episode.get("episode_uid") or "").strip()
+    canonical = answer.strip()
+    return MemoryCandidate(
+        memory_type="knowledge_memory",
+        title=prompt[:80] or "知识事实",
+        content=answer,
+        canonical_text=canonical,
+        dedup_key=f"knowledge:{prompt[:80]}",
+        confidence=0.7,
+        source_episode_uid=episode_uid,
+        evidence=[{"episode_uid": episode_uid, "quote": answer}],
+    )
+
+
+def extract_memory_candidates(
+    *,
+    episode: dict[str, Any],
+    recent_episodes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    del recent_episodes
+    prompt = str(episode.get("prompt") or "").lower()
+    answer = str(episode.get("answer") or "").strip()
+    if not prompt or not answer:
+        return []
+
+    user_markers = ["请记住", "以后", "默认", "风格", "格式", "回答"]
+    knowledge_markers = ["是什么", "结论", "数据集", "方法", "定义", "概念"]
+
+    candidates: list[MemoryCandidate] = []
+    if any(marker in prompt for marker in user_markers):
+        candidates.append(_build_user_memory_candidate(episode))
+    elif any(marker in prompt for marker in knowledge_markers):
+        candidates.append(_build_knowledge_memory_candidate(episode))
+
+    return [candidate.model_dump() for candidate in candidates]

--- a/agent/memory/extraction.py
+++ b/agent/memory/extraction.py
@@ -1,6 +1,84 @@
+import json
+import sqlite3
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from agent.llm_provider import build_openai_compatible_chat_model
+
+VALID_MEMORY_ACTIONS = {"ADD", "UPDATE", "DELETE", "NONE", "SUPERSEDE"}
+VALID_MEMORY_TYPES = {"user_memory", "knowledge_memory"}
+
+MEMORY_EXTRACTION_SYSTEM_PROMPT = """
+You are a long-term memory extraction agent.
+
+Your job:
+1. Read the current conversation episode, recent episodes, and existing active memories.
+2. Decide whether this turn contains durable long-term memory worth saving.
+3. Return only structured memory candidates in JSON.
+
+Rules:
+- Do not use keyword heuristics. Judge from meaning and conversational intent.
+- Extract only durable memory. Ignore small talk, transient requests, and one-off acknowledgements.
+- `user_memory` is for stable user preferences, response instructions, and long-lived constraints.
+- `knowledge_memory` is for durable project or paper facts worth recalling later.
+- Every candidate must include:
+  - `action`: one of ADD, UPDATE, DELETE, NONE, SUPERSEDE
+  - `memory_type`: `user_memory` or `knowledge_memory`
+  - `title`
+  - `content`
+  - `canonical_text`
+  - `dedup_key`
+  - `confidence`: 0 to 1
+  - `evidence`: list of short supporting quotes from the current episode
+- If nothing should be saved, return `{ "candidates": [] }`.
+
+Output requirements:
+- Return strict JSON only.
+- Top-level object must be `{ "candidates": [...] }`.
+""".strip()
+
+
+def _read_user_column(*, uuid: str, column: str, db_name: str = "./database.sqlite") -> str | None:
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT {column} FROM users WHERE uuid = ?", (uuid,))
+    row = cursor.fetchone()
+    conn.close()
+    if not row:
+        return None
+    value = row[0]
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def read_api_key_for_user(*, uuid: str, db_name: str = "./database.sqlite") -> str:
+    return _read_user_column(uuid=uuid, column="api_key", db_name=db_name) or ""
+
+
+def read_model_name_for_user(*, uuid: str, db_name: str = "./database.sqlite") -> str | None:
+    return _read_user_column(uuid=uuid, column="model_name", db_name=db_name)
+
+
+def read_base_url_for_user(*, uuid: str, db_name: str = "./database.sqlite") -> str | None:
+    return _read_user_column(uuid=uuid, column="base_url", db_name=db_name)
+
+
+def create_chat_model(
+    *,
+    api_key: str,
+    model_name: str,
+    base_url: str | None = None,
+    temperature: float | None = None,
+):
+    return build_openai_compatible_chat_model(
+        api_key=api_key,
+        model_name=model_name,
+        base_url=base_url,
+        temperature=temperature,
+    )
 
 
 class MemoryCandidate(BaseModel):
@@ -11,62 +89,183 @@ class MemoryCandidate(BaseModel):
     canonical_text: str
     dedup_key: str
     confidence: float = 0.0
-    source_episode_uid: str
+    source_episode_uid: str = ""
     evidence: list[dict[str, Any]] = Field(default_factory=list)
 
+    @field_validator("action")
+    @classmethod
+    def _validate_action(cls, value: str) -> str:
+        normalized = str(value or "").strip().upper() or "ADD"
+        if normalized not in VALID_MEMORY_ACTIONS:
+            raise ValueError(f"unsupported action: {normalized}")
+        return normalized
 
-def _build_user_memory_candidate(episode: dict[str, Any]) -> MemoryCandidate:
-    prompt = str(episode.get("prompt") or "").strip()
-    answer = str(episode.get("answer") or "").strip()
-    episode_uid = str(episode.get("episode_uid") or "").strip()
-    canonical = prompt.replace("请记住", "").strip("，,。. ")
-    return MemoryCandidate(
-        memory_type="user_memory",
-        title=prompt[:80] or "用户偏好",
-        content=f"{prompt}\n{answer}".strip(),
-        canonical_text=canonical or prompt,
-        dedup_key="user:response_preferences",
-        confidence=0.85,
-        source_episode_uid=episode_uid,
-        evidence=[{"episode_uid": episode_uid, "quote": prompt}],
-    )
+    @field_validator("memory_type")
+    @classmethod
+    def _validate_memory_type(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in VALID_MEMORY_TYPES:
+            raise ValueError(f"unsupported memory_type: {normalized}")
+        return normalized
+
+    @field_validator("title", "content", "canonical_text", "dedup_key")
+    @classmethod
+    def _validate_non_empty_text(cls, value: str) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("required text field is empty")
+        return normalized
+
+    @field_validator("confidence")
+    @classmethod
+    def _clamp_confidence(cls, value: float) -> float:
+        normalized = float(value or 0.0)
+        if normalized < 0.0:
+            return 0.0
+        if normalized > 1.0:
+            return 1.0
+        return normalized
 
 
-def _build_knowledge_memory_candidate(episode: dict[str, Any]) -> MemoryCandidate:
-    prompt = str(episode.get("prompt") or "").strip()
-    answer = str(episode.get("answer") or "").strip()
-    episode_uid = str(episode.get("episode_uid") or "").strip()
-    canonical = answer.strip()
-    return MemoryCandidate(
-        memory_type="knowledge_memory",
-        title=prompt[:80] or "知识事实",
-        content=answer,
-        canonical_text=canonical,
-        dedup_key=f"knowledge:{prompt[:80]}",
-        confidence=0.7,
-        source_episode_uid=episode_uid,
-        evidence=[{"episode_uid": episode_uid, "quote": answer}],
-    )
+class MemoryExtractionResult(BaseModel):
+    candidates: list[MemoryCandidate] = Field(default_factory=list)
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part).strip()
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _extract_json_object(raw_text: str) -> str:
+    text = str(raw_text or "").strip()
+    if not text:
+        raise ValueError("memory extractor returned empty content")
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end < start:
+        raise ValueError("memory extractor did not return a JSON object")
+    return text[start : end + 1]
+
+
+def _normalize_evidence(
+    evidence_items: list[dict[str, Any]],
+    *,
+    episode_uid: str,
+) -> list[dict[str, Any]]:
+    normalized_items: list[dict[str, Any]] = []
+    for item in evidence_items:
+        if not isinstance(item, dict):
+            continue
+        normalized = dict(item)
+        if not str(normalized.get("episode_uid") or "").strip():
+            normalized["episode_uid"] = episode_uid
+        normalized_items.append(normalized)
+    return normalized_items
+
+
+def _serialize_extraction_context(
+    *,
+    episode: dict[str, Any],
+    recent_episodes: list[dict[str, Any]],
+    active_memories: list[dict[str, Any]],
+) -> str:
+    payload = {
+        "episode": {
+            "episode_uid": str(episode.get("episode_uid") or ""),
+            "prompt": str(episode.get("prompt") or ""),
+            "answer": str(episode.get("answer") or ""),
+        },
+        "recent_episodes": [
+            {
+                "episode_uid": str(item.get("episode_uid") or ""),
+                "prompt": str(item.get("prompt") or ""),
+                "answer": str(item.get("answer") or ""),
+            }
+            for item in recent_episodes[:5]
+            if isinstance(item, dict)
+        ],
+        "active_memories": [
+            {
+                "memory_uid": str(item.get("memory_uid") or ""),
+                "memory_type": str(item.get("memory_type") or ""),
+                "canonical_text": str(item.get("canonical_text") or ""),
+                "content": str(item.get("content") or ""),
+                "dedup_key": str(item.get("dedup_key") or ""),
+                "status": str(item.get("status") or ""),
+            }
+            for item in active_memories[:20]
+            if isinstance(item, dict)
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def extract_memory_candidates(
     *,
     episode: dict[str, Any],
     recent_episodes: list[dict[str, Any]],
+    active_memories: list[dict[str, Any]],
+    user_uuid: str,
 ) -> list[dict[str, Any]]:
-    del recent_episodes
-    prompt = str(episode.get("prompt") or "").lower()
+    prompt = str(episode.get("prompt") or "").strip()
     answer = str(episode.get("answer") or "").strip()
-    if not prompt or not answer:
+    episode_uid = str(episode.get("episode_uid") or "").strip()
+    if not prompt or not answer or not episode_uid:
         return []
 
-    user_markers = ["请记住", "以后", "默认", "风格", "格式", "回答"]
-    knowledge_markers = ["是什么", "结论", "数据集", "方法", "定义", "概念"]
+    api_key = read_api_key_for_user(uuid=user_uuid)
+    if not api_key:
+        raise ValueError("memory extraction requires a configured API key")
+    model_name = read_model_name_for_user(uuid=user_uuid)
+    if not model_name:
+        raise ValueError("memory extraction requires a configured model name")
+    base_url = read_base_url_for_user(uuid=user_uuid)
 
-    candidates: list[MemoryCandidate] = []
-    if any(marker in prompt for marker in user_markers):
-        candidates.append(_build_user_memory_candidate(episode))
-    elif any(marker in prompt for marker in knowledge_markers):
-        candidates.append(_build_knowledge_memory_candidate(episode))
+    llm = create_chat_model(
+        api_key=api_key,
+        model_name=model_name,
+        base_url=base_url,
+        temperature=0.0,
+    )
+    result = llm.invoke(
+        [
+            ("system", MEMORY_EXTRACTION_SYSTEM_PROMPT),
+            (
+                "user",
+                _serialize_extraction_context(
+                    episode=episode,
+                    recent_episodes=recent_episodes,
+                    active_memories=active_memories,
+                ),
+            ),
+        ]
+    )
+    result_text = _content_to_text(getattr(result, "content", result))
+    try:
+        parsed = MemoryExtractionResult.model_validate_json(_extract_json_object(result_text))
+    except ValidationError as exc:
+        raise ValueError(f"memory extractor returned invalid payload: {exc}") from exc
 
-    return [candidate.model_dump() for candidate in candidates]
+    candidates: list[dict[str, Any]] = []
+    for candidate in parsed.candidates:
+        normalized = candidate.model_dump()
+        normalized["source_episode_uid"] = episode_uid
+        normalized["evidence"] = _normalize_evidence(
+            list(normalized.get("evidence") or []),
+            episode_uid=episode_uid,
+        )
+        candidates.append(normalized)
+    return candidates

--- a/agent/memory/reconcile.py
+++ b/agent/memory/reconcile.py
@@ -1,0 +1,163 @@
+from typing import Any
+
+from .store import list_project_memory_items, update_memory_item_status, upsert_project_memory_item
+
+
+def apply_memory_candidates(
+    *,
+    uuid: str,
+    project_uid: str,
+    session_uid: str,
+    candidates: list[dict[str, Any]],
+    db_name: str = "./database.sqlite",
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    active_items = list_project_memory_items(
+        uuid=uuid,
+        project_uid=project_uid,
+        status="active",
+        limit=200,
+        db_name=db_name,
+    )
+    for candidate in candidates:
+        requested_action = str(candidate.get("action") or "ADD").strip().upper() or "ADD"
+        dedup_key = str(candidate.get("dedup_key") or "").strip()
+        canonical_text = str(candidate.get("canonical_text") or "").strip()
+        existing = next(
+            (
+                item
+                for item in active_items
+                if str(item.get("dedup_key") or "").strip() == dedup_key
+                and str(item.get("memory_type") or "").strip()
+                == str(candidate.get("memory_type") or "").strip()
+            ),
+            None,
+        )
+        if requested_action == "DELETE" and existing:
+            update_memory_item_status(
+                memory_uid=str(existing.get("memory_uid") or ""),
+                status="deleted",
+                db_name=db_name,
+            )
+            results.append(
+                {
+                    "action": "DELETE",
+                    "memory_uid": str(existing.get("memory_uid") or ""),
+                    "dedup_key": dedup_key,
+                }
+            )
+            active_items = [
+                item
+                for item in active_items
+                if str(item.get("memory_uid") or "") != str(existing.get("memory_uid") or "")
+            ]
+            continue
+
+        if existing and str(existing.get("canonical_text") or "").strip() == canonical_text:
+            results.append(
+                {
+                    "action": "NONE",
+                    "memory_uid": str(existing.get("memory_uid") or ""),
+                    "dedup_key": dedup_key,
+                }
+            )
+            continue
+
+        if requested_action == "UPDATE" and existing:
+            memory_uid = upsert_project_memory_item(
+                uuid=uuid,
+                project_uid=project_uid,
+                session_uid=session_uid,
+                memory_type=str(candidate.get("memory_type") or ""),
+                title=str(candidate.get("title") or ""),
+                content=str(candidate.get("content") or ""),
+                canonical_text=canonical_text,
+                dedup_key=dedup_key,
+                status="active",
+                confidence=float(candidate.get("confidence") or 0.0),
+                source_episode_uid=str(candidate.get("source_episode_uid") or ""),
+                evidence=list(candidate.get("evidence") or []),
+                db_name=db_name,
+            )
+            results.append(
+                {
+                    "action": "UPDATE",
+                    "memory_uid": memory_uid,
+                    "dedup_key": dedup_key,
+                }
+            )
+            for item in active_items:
+                if str(item.get("memory_uid") or "") == memory_uid:
+                    item.update(candidate)
+                    item["status"] = "active"
+            continue
+
+        if existing:
+            new_uid = upsert_project_memory_item(
+                uuid=uuid,
+                project_uid=project_uid,
+                session_uid=session_uid,
+                memory_type=str(candidate.get("memory_type") or ""),
+                title=str(candidate.get("title") or ""),
+                content=str(candidate.get("content") or ""),
+                canonical_text=canonical_text,
+                dedup_key=dedup_key,
+                status="active",
+                confidence=float(candidate.get("confidence") or 0.0),
+                source_episode_uid=str(candidate.get("source_episode_uid") or ""),
+                evidence=list(candidate.get("evidence") or []),
+                allow_update=False,
+                db_name=db_name,
+            )
+            update_memory_item_status(
+                memory_uid=str(existing.get("memory_uid") or ""),
+                status="superseded",
+                superseded_by=new_uid,
+                db_name=db_name,
+            )
+            results.append(
+                {
+                    "action": "SUPERSEDE",
+                    "memory_uid": new_uid,
+                    "previous_memory_uid": str(existing.get("memory_uid") or ""),
+                    "dedup_key": dedup_key,
+                }
+            )
+            active_items = [
+                item
+                for item in active_items
+                if str(item.get("memory_uid") or "") != str(existing.get("memory_uid") or "")
+            ]
+            created_item = dict(candidate)
+            created_item["memory_uid"] = new_uid
+            created_item["status"] = "active"
+            active_items.append(created_item)
+            continue
+
+        memory_uid = upsert_project_memory_item(
+            uuid=uuid,
+            project_uid=project_uid,
+            session_uid=session_uid,
+            memory_type=str(candidate.get("memory_type") or ""),
+            title=str(candidate.get("title") or ""),
+            content=str(candidate.get("content") or ""),
+            canonical_text=canonical_text,
+            dedup_key=dedup_key,
+            status="active",
+            confidence=float(candidate.get("confidence") or 0.0),
+            source_episode_uid=str(candidate.get("source_episode_uid") or ""),
+            evidence=list(candidate.get("evidence") or []),
+            db_name=db_name,
+        )
+        results.append(
+            {
+                "action": "ADD",
+                "memory_uid": memory_uid,
+                "dedup_key": dedup_key,
+            }
+        )
+        created_item = dict(candidate)
+        created_item["memory_uid"] = memory_uid
+        created_item["status"] = "active"
+        active_items.append(created_item)
+    return results

--- a/agent/memory/repository.py
+++ b/agent/memory/repository.py
@@ -9,6 +9,63 @@ def _now_str() -> str:
     return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _json_dumps(value: Any, *, fallback: Any) -> str:
+    payload = value if value is not None else fallback
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _ensure_memory_item_columns(cursor: sqlite3.Cursor) -> None:
+    cursor.execute("PRAGMA table_info(memory_items)")
+    memory_columns = {row[1] for row in cursor.fetchall()}
+    alter_statements = {
+        "expires_at": "ALTER TABLE memory_items ADD COLUMN expires_at TEXT DEFAULT ''",
+        "canonical_text": "ALTER TABLE memory_items ADD COLUMN canonical_text TEXT DEFAULT ''",
+        "dedup_key": "ALTER TABLE memory_items ADD COLUMN dedup_key TEXT DEFAULT ''",
+        "status": "ALTER TABLE memory_items ADD COLUMN status TEXT DEFAULT 'active'",
+        "confidence": "ALTER TABLE memory_items ADD COLUMN confidence REAL DEFAULT 0",
+        "source_episode_uid": "ALTER TABLE memory_items ADD COLUMN source_episode_uid TEXT DEFAULT ''",
+        "evidence_json": "ALTER TABLE memory_items ADD COLUMN evidence_json TEXT DEFAULT '[]'",
+        "superseded_by": "ALTER TABLE memory_items ADD COLUMN superseded_by TEXT DEFAULT ''",
+    }
+    for column, statement in alter_statements.items():
+        if column not in memory_columns:
+            cursor.execute(statement)
+
+
+def _parse_json_list(value: Any) -> list[Any]:
+    if not isinstance(value, str) or not value.strip():
+        return []
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _row_to_memory_item(row: tuple[Any, ...]) -> dict[str, Any]:
+    return {
+        "memory_uid": str(row[0] or ""),
+        "session_uid": str(row[1] or ""),
+        "memory_type": str(row[2] or ""),
+        "title": str(row[3] or ""),
+        "content": str(row[4] or ""),
+        "source_prompt": str(row[5] or ""),
+        "source_answer": str(row[6] or ""),
+        "access_count": int(row[7] or 0),
+        "created_at": str(row[8] or ""),
+        "updated_at": str(row[9] or ""),
+        "last_accessed_at": str(row[10] or ""),
+        "expires_at": str(row[11] or ""),
+        "canonical_text": str(row[12] or ""),
+        "dedup_key": str(row[13] or ""),
+        "status": str(row[14] or "active"),
+        "confidence": float(row[15] or 0.0),
+        "source_episode_uid": str(row[16] or ""),
+        "evidence": _parse_json_list(row[17]),
+        "superseded_by": str(row[18] or ""),
+    }
+
+
 def ensure_memory_tables(db_name: str = "./database.sqlite") -> None:
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
@@ -23,6 +80,20 @@ def ensure_memory_tables(db_name: str = "./database.sqlite") -> None:
             anchors_json TEXT DEFAULT '[]',
             updated_at TEXT NOT NULL,
             UNIQUE(session_uid, project_uid, uuid)
+        )
+    """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_episodes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            episode_uid TEXT UNIQUE NOT NULL,
+            uuid TEXT NOT NULL,
+            project_uid TEXT NOT NULL,
+            session_uid TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            answer TEXT NOT NULL,
+            created_at TEXT NOT NULL
         )
     """
     )
@@ -43,12 +114,34 @@ def ensure_memory_tables(db_name: str = "./database.sqlite") -> None:
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             last_accessed_at TEXT,
-            expires_at TEXT DEFAULT ''
+            expires_at TEXT DEFAULT '',
+            canonical_text TEXT DEFAULT '',
+            dedup_key TEXT DEFAULT '',
+            status TEXT DEFAULT 'active',
+            confidence REAL DEFAULT 0,
+            source_episode_uid TEXT DEFAULT '',
+            evidence_json TEXT DEFAULT '[]',
+            superseded_by TEXT DEFAULT ''
         )
     """
     )
     cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_item_evidence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_uid TEXT NOT NULL,
+            episode_uid TEXT NOT NULL,
+            evidence_json TEXT DEFAULT '{}',
+            created_at TEXT NOT NULL
+        )
+    """
+    )
+    _ensure_memory_item_columns(cursor)
+    cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_session_compact_scope ON session_compact_memory(session_uid, project_uid, uuid)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_episodes_scope ON memory_episodes(uuid, project_uid, session_uid, created_at DESC)"
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_items_scope ON memory_items(uuid, project_uid, memory_type, updated_at DESC)"
@@ -59,10 +152,18 @@ def ensure_memory_tables(db_name: str = "./database.sqlite") -> None:
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_items_expire ON memory_items(expires_at)"
     )
-    cursor.execute("PRAGMA table_info(memory_items)")
-    memory_columns = {row[1] for row in cursor.fetchall()}
-    if "expires_at" not in memory_columns:
-        cursor.execute("ALTER TABLE memory_items ADD COLUMN expires_at TEXT DEFAULT ''")
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_active_lookup ON memory_items(uuid, project_uid, status, updated_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_dedup_key ON memory_items(dedup_key)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_episode ON memory_items(source_episode_uid, updated_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_item_evidence_memory ON memory_item_evidence(memory_uid, episode_uid)"
+    )
     conn.commit()
     conn.close()
 
@@ -91,18 +192,9 @@ def get_project_session_compact_memory(
         return {"compact_summary": "", "anchors": [], "updated_at": ""}
 
     compact_summary = str(row[0] or "")
-    anchors_raw = row[1]
-    anchors: list[Any] = []
-    if isinstance(anchors_raw, str) and anchors_raw.strip():
-        try:
-            parsed = json.loads(anchors_raw)
-            if isinstance(parsed, list):
-                anchors = parsed
-        except Exception:
-            anchors = []
     return {
         "compact_summary": compact_summary,
-        "anchors": anchors,
+        "anchors": _parse_json_list(row[1]),
         "updated_at": str(row[2] or ""),
     }
 
@@ -117,7 +209,6 @@ def save_project_session_compact_memory(
 ) -> None:
     ensure_memory_tables(db_name)
     now = _now_str()
-    anchors_payload = anchors if isinstance(anchors, list) else []
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
     cursor.execute(
@@ -136,12 +227,154 @@ def save_project_session_compact_memory(
             project_uid,
             uuid,
             str(compact_summary or ""),
-            json.dumps(anchors_payload, ensure_ascii=False),
+            _json_dumps(anchors, fallback=[]),
             now,
         ),
     )
     conn.commit()
     conn.close()
+
+
+def save_project_memory_episode(
+    *,
+    uuid: str,
+    project_uid: str,
+    session_uid: str,
+    prompt: str,
+    answer: str,
+    db_name: str = "./database.sqlite",
+) -> str:
+    ensure_memory_tables(db_name)
+    prompt_text = str(prompt or "").strip()
+    answer_text = str(answer or "").strip()
+    if not prompt_text or not answer_text:
+        return ""
+    now = _now_str()
+    episode_uid = uuid4().hex
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO memory_episodes (
+            episode_uid, uuid, project_uid, session_uid, prompt, answer, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """,
+        (
+            episode_uid,
+            uuid,
+            project_uid,
+            session_uid,
+            prompt_text,
+            answer_text,
+            now,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return episode_uid
+
+
+def get_project_memory_episode(
+    *,
+    episode_uid: str,
+    db_name: str = "./database.sqlite",
+) -> dict[str, Any]:
+    ensure_memory_tables(db_name)
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT episode_uid, uuid, project_uid, session_uid, prompt, answer, created_at
+        FROM memory_episodes
+        WHERE episode_uid = ?
+        LIMIT 1
+    """,
+        (str(episode_uid or "").strip(),),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    if not row:
+        return {}
+    return {
+        "episode_uid": str(row[0] or ""),
+        "uuid": str(row[1] or ""),
+        "project_uid": str(row[2] or ""),
+        "session_uid": str(row[3] or ""),
+        "prompt": str(row[4] or ""),
+        "answer": str(row[5] or ""),
+        "created_at": str(row[6] or ""),
+    }
+
+
+def list_project_memory_episodes(
+    *,
+    uuid: str,
+    project_uid: str,
+    session_uid: str | None = None,
+    limit: int = 5,
+    db_name: str = "./database.sqlite",
+) -> list[dict[str, Any]]:
+    ensure_memory_tables(db_name)
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    params: list[Any] = [uuid, project_uid]
+    clauses = ["uuid = ?", "project_uid = ?"]
+    if isinstance(session_uid, str) and session_uid.strip():
+        clauses.append("session_uid = ?")
+        params.append(session_uid.strip())
+    params.append(max(1, int(limit)))
+    cursor.execute(
+        f"""
+        SELECT episode_uid, uuid, project_uid, session_uid, prompt, answer, created_at
+        FROM memory_episodes
+        WHERE {" AND ".join(clauses)}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+    """,
+        tuple(params),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return [
+        {
+            "episode_uid": str(row[0] or ""),
+            "uuid": str(row[1] or ""),
+            "project_uid": str(row[2] or ""),
+            "session_uid": str(row[3] or ""),
+            "prompt": str(row[4] or ""),
+            "answer": str(row[5] or ""),
+            "created_at": str(row[6] or ""),
+        }
+        for row in rows
+    ]
+
+
+def _replace_memory_item_evidence(
+    *,
+    cursor: sqlite3.Cursor,
+    memory_uid: str,
+    source_episode_uid: str,
+    evidence: list[dict[str, Any]],
+    now: str,
+) -> None:
+    cursor.execute("DELETE FROM memory_item_evidence WHERE memory_uid = ?", (memory_uid,))
+    if not evidence:
+        return
+    normalized_episode_uid = str(source_episode_uid or "").strip()
+    for item in evidence:
+        cursor.execute(
+            """
+            INSERT INTO memory_item_evidence (memory_uid, episode_uid, evidence_json, created_at)
+            VALUES (?, ?, ?, ?)
+        """,
+            (
+                memory_uid,
+                str(item.get("episode_uid") or normalized_episode_uid),
+                _json_dumps(item, fallback={}),
+                now,
+            ),
+        )
 
 
 def upsert_project_memory_item(
@@ -155,6 +388,12 @@ def upsert_project_memory_item(
     source_prompt: str = "",
     source_answer: str = "",
     expires_at: str = "",
+    canonical_text: str = "",
+    dedup_key: str = "",
+    status: str = "active",
+    confidence: float = 0.0,
+    source_episode_uid: str = "",
+    evidence: list[dict[str, Any]] | None = None,
     db_name: str = "./database.sqlite",
 ) -> str:
     ensure_memory_tables(db_name)
@@ -162,36 +401,68 @@ def upsert_project_memory_item(
     if not normalized_content:
         return ""
     normalized_type = str(memory_type or "episodic").strip().lower() or "episodic"
+    normalized_canonical = str(canonical_text or "").strip() or normalized_content
+    normalized_dedup_key = str(dedup_key or "").strip()
+    normalized_status = str(status or "active").strip().lower() or "active"
+    normalized_confidence = float(confidence or 0.0)
+    evidence_payload = evidence if isinstance(evidence, list) else []
     now = _now_str()
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT memory_uid
-        FROM memory_items
-        WHERE uuid = ? AND project_uid = ? AND memory_type = ? AND content = ?
-        LIMIT 1
-    """,
-        (uuid, project_uid, normalized_type, normalized_content),
-    )
+    if normalized_dedup_key:
+        cursor.execute(
+            """
+            SELECT memory_uid
+            FROM memory_items
+            WHERE uuid = ? AND project_uid = ? AND dedup_key = ?
+            LIMIT 1
+        """,
+            (uuid, project_uid, normalized_dedup_key),
+        )
+    else:
+        cursor.execute(
+            """
+            SELECT memory_uid
+            FROM memory_items
+            WHERE uuid = ? AND project_uid = ? AND memory_type = ? AND content = ?
+            LIMIT 1
+        """,
+            (uuid, project_uid, normalized_type, normalized_content),
+        )
     row = cursor.fetchone()
     if row:
         memory_uid = str(row[0] or "")
         cursor.execute(
             """
             UPDATE memory_items
-            SET session_uid = ?, title = ?, source_prompt = ?, source_answer = ?, updated_at = ?, expires_at = ?
+            SET session_uid = ?, title = ?, content = ?, source_prompt = ?, source_answer = ?,
+                updated_at = ?, expires_at = ?, canonical_text = ?, dedup_key = ?, status = ?,
+                confidence = ?, source_episode_uid = ?, evidence_json = ?
             WHERE memory_uid = ?
         """,
             (
                 str(session_uid or ""),
                 str(title or ""),
+                normalized_content,
                 str(source_prompt or ""),
                 str(source_answer or ""),
                 now,
                 str(expires_at or ""),
+                normalized_canonical,
+                normalized_dedup_key,
+                normalized_status,
+                normalized_confidence,
+                str(source_episode_uid or ""),
+                _json_dumps(evidence_payload, fallback=[]),
                 memory_uid,
             ),
+        )
+        _replace_memory_item_evidence(
+            cursor=cursor,
+            memory_uid=memory_uid,
+            source_episode_uid=str(source_episode_uid or ""),
+            evidence=evidence_payload,
+            now=now,
         )
         conn.commit()
         conn.close()
@@ -202,9 +473,11 @@ def upsert_project_memory_item(
         """
         INSERT INTO memory_items (
             memory_uid, uuid, project_uid, session_uid, memory_type, title, content,
-            source_prompt, source_answer, access_count, created_at, updated_at, last_accessed_at, expires_at
+            source_prompt, source_answer, access_count, created_at, updated_at, last_accessed_at,
+            expires_at, canonical_text, dedup_key, status, confidence, source_episode_uid,
+            evidence_json, superseded_by
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, '', ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, '')
     """,
         (
             memory_uid,
@@ -219,7 +492,20 @@ def upsert_project_memory_item(
             now,
             now,
             str(expires_at or ""),
+            normalized_canonical,
+            normalized_dedup_key,
+            normalized_status,
+            normalized_confidence,
+            str(source_episode_uid or ""),
+            _json_dumps(evidence_payload, fallback=[]),
         ),
+    )
+    _replace_memory_item_evidence(
+        cursor=cursor,
+        memory_uid=memory_uid,
+        source_episode_uid=str(source_episode_uid or ""),
+        evidence=evidence_payload,
+        now=now,
     )
     conn.commit()
     conn.close()
@@ -233,6 +519,7 @@ def list_project_memory_items(
     memory_type: str | None = None,
     limit: int = 100,
     include_expired: bool = False,
+    status: str | None = None,
     db_name: str = "./database.sqlite",
 ) -> list[dict[str, Any]]:
     ensure_memory_tables(db_name)
@@ -240,59 +527,34 @@ def list_project_memory_items(
     cursor = conn.cursor()
     resolved_limit = max(1, int(limit))
     now = _now_str()
-    expire_condition = ""
+    clauses = ["uuid = ?", "project_uid = ?"]
     params: list[Any] = [uuid, project_uid]
     if not include_expired:
-        expire_condition = "AND (expires_at = '' OR expires_at > ?)"
+        clauses.append("(expires_at = '' OR expires_at > ?)")
         params.append(now)
     if isinstance(memory_type, str) and memory_type.strip():
+        clauses.append("memory_type = ?")
         params.append(memory_type.strip().lower())
-        params.append(resolved_limit)
-        cursor.execute(
-            """
-            SELECT memory_uid, session_uid, memory_type, title, content, source_prompt,
-                   source_answer, access_count, created_at, updated_at, last_accessed_at, expires_at
-            FROM memory_items
-            WHERE uuid = ? AND project_uid = ? AND memory_type = ?
-            {expire_condition}
-            ORDER BY updated_at DESC, id DESC
-            LIMIT ?
-        """.format(expire_condition=expire_condition),
-            tuple(params),
-        )
-    else:
-        params.append(resolved_limit)
-        cursor.execute(
-            """
-            SELECT memory_uid, session_uid, memory_type, title, content, source_prompt,
-                   source_answer, access_count, created_at, updated_at, last_accessed_at, expires_at
-            FROM memory_items
-            WHERE uuid = ? AND project_uid = ?
-            {expire_condition}
-            ORDER BY updated_at DESC, id DESC
-            LIMIT ?
-        """.format(expire_condition=expire_condition),
-            tuple(params),
-        )
+    if isinstance(status, str) and status.strip():
+        clauses.append("status = ?")
+        params.append(status.strip().lower())
+    params.append(resolved_limit)
+    cursor.execute(
+        f"""
+        SELECT memory_uid, session_uid, memory_type, title, content, source_prompt,
+               source_answer, access_count, created_at, updated_at, last_accessed_at, expires_at,
+               canonical_text, dedup_key, status, confidence, source_episode_uid, evidence_json,
+               superseded_by
+        FROM memory_items
+        WHERE {" AND ".join(clauses)}
+        ORDER BY updated_at DESC, id DESC
+        LIMIT ?
+    """,
+        tuple(params),
+    )
     rows = cursor.fetchall()
     conn.close()
-    return [
-        {
-            "memory_uid": str(row[0] or ""),
-            "session_uid": str(row[1] or ""),
-            "memory_type": str(row[2] or ""),
-            "title": str(row[3] or ""),
-            "content": str(row[4] or ""),
-            "source_prompt": str(row[5] or ""),
-            "source_answer": str(row[6] or ""),
-            "access_count": int(row[7] or 0),
-            "created_at": str(row[8] or ""),
-            "updated_at": str(row[9] or ""),
-            "last_accessed_at": str(row[10] or ""),
-            "expires_at": str(row[11] or ""),
-        }
-        for row in rows
-    ]
+    return [_row_to_memory_item(row) for row in rows]
 
 
 def touch_memory_items(

--- a/agent/memory/repository.py
+++ b/agent/memory/repository.py
@@ -394,6 +394,7 @@ def upsert_project_memory_item(
     confidence: float = 0.0,
     source_episode_uid: str = "",
     evidence: list[dict[str, Any]] | None = None,
+    allow_update: bool = True,
     db_name: str = "./database.sqlite",
 ) -> str:
     ensure_memory_tables(db_name)
@@ -409,7 +410,7 @@ def upsert_project_memory_item(
     now = _now_str()
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
-    if normalized_dedup_key:
+    if allow_update and normalized_dedup_key:
         cursor.execute(
             """
             SELECT memory_uid
@@ -419,7 +420,7 @@ def upsert_project_memory_item(
         """,
             (uuid, project_uid, normalized_dedup_key),
         )
-    else:
+    elif allow_update:
         cursor.execute(
             """
             SELECT memory_uid
@@ -429,7 +430,7 @@ def upsert_project_memory_item(
         """,
             (uuid, project_uid, normalized_type, normalized_content),
         )
-    row = cursor.fetchone()
+    row = cursor.fetchone() if allow_update else None
     if row:
         memory_uid = str(row[0] or "")
         cursor.execute(
@@ -510,6 +511,34 @@ def upsert_project_memory_item(
     conn.commit()
     conn.close()
     return memory_uid
+
+
+def update_memory_item_status(
+    *,
+    memory_uid: str,
+    status: str,
+    superseded_by: str = "",
+    db_name: str = "./database.sqlite",
+) -> None:
+    ensure_memory_tables(db_name)
+    now = _now_str()
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        UPDATE memory_items
+        SET status = ?, superseded_by = ?, updated_at = ?
+        WHERE memory_uid = ?
+    """,
+        (
+            str(status or "active").strip().lower() or "active",
+            str(superseded_by or ""),
+            now,
+            str(memory_uid or "").strip(),
+        ),
+    )
+    conn.commit()
+    conn.close()
 
 
 def list_project_memory_items(

--- a/agent/memory/service.py
+++ b/agent/memory/service.py
@@ -27,12 +27,16 @@ def search_project_memory_items(
     uuid: str,
     project_uid: str,
     query: str,
+    memory_type: str | None = None,
+    status: str | None = "active",
     limit: int = 5,
     db_name: str = "./database.sqlite",
 ) -> list[dict[str, Any]]:
     base_items = list_project_memory_items(
         uuid=uuid,
         project_uid=project_uid,
+        memory_type=memory_type,
+        status=status,
         limit=max(20, int(limit) * 10),
         db_name=db_name,
     )
@@ -45,15 +49,19 @@ def search_project_memory_items(
     for item in base_items:
         content = str(item.get("content") or "")
         title = str(item.get("title") or "")
+        canonical = str(item.get("canonical_text") or "")
         content_lower = content.lower()
         title_lower = title.lower()
-        item_terms = _memory_term_set(f"{title}\n{content}")
+        canonical_lower = canonical.lower()
+        item_terms = _memory_term_set(f"{title}\n{canonical}\n{content}")
         overlap = len(query_terms & item_terms) if query_terms else 0
         partial_hits = 0
         for term in query_terms:
-            if term in content_lower or term in title_lower:
+            if term in content_lower or term in title_lower or term in canonical_lower:
                 partial_hits += 1
-        text_bonus = 1.0 if query_text and query_text in content_lower else 0.0
+        text_bonus = 1.0 if query_text and (
+            query_text in content_lower or query_text in canonical_lower
+        ) else 0.0
         recency = _memory_recency_score(str(item.get("updated_at") or ""))
         score = overlap * 3.0 + partial_hits * 1.5 + text_bonus + recency
         if query_terms and overlap <= 0 and partial_hits <= 0 and text_bonus <= 0:
@@ -64,6 +72,13 @@ def search_project_memory_items(
 
     if not scored and not query_terms:
         return base_items[: max(1, int(limit))]
+    if not scored and isinstance(memory_type, str) and memory_type.strip().lower() == "knowledge_memory":
+        top_items = base_items[: max(1, int(limit))]
+        touch_memory_items(
+            memory_uids=[str(item.get("memory_uid") or "") for item in top_items],
+            db_name=db_name,
+        )
+        return top_items
 
     scored.sort(key=lambda pair: pair[0], reverse=True)
     top_items = [item for _, item in scored[: max(1, int(limit))]]

--- a/agent/memory/service.py
+++ b/agent/memory/service.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import re
 from typing import Any
 
@@ -87,3 +88,66 @@ def search_project_memory_items(
         db_name=db_name,
     )
     return top_items
+
+
+def _stable_memory_dedup_key(*, memory_type: str, canonical_text: str) -> str:
+    normalized_type = str(memory_type or "").strip().lower()
+    normalized_text = " ".join(str(canonical_text or "").strip().lower().split())
+    digest = hashlib.sha1(f"{normalized_type}:{normalized_text}".encode("utf-8")).hexdigest()
+    return f"{normalized_type}:{digest[:16]}"
+
+
+def write_memory_from_leader(
+    *,
+    uuid: str,
+    project_uid: str,
+    session_uid: str,
+    items: list[dict[str, Any]],
+    db_name: str = "./database.sqlite",
+) -> list[dict[str, Any]]:
+    from .reconcile import apply_memory_candidates
+
+    candidates: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        memory_type = str(item.get("memory_type") or "").strip().lower()
+        content = " ".join(str(item.get("content") or "").split()).strip()
+        canonical_text = " ".join(
+            str(item.get("canonical_text") or content).split()
+        ).strip()
+        if not memory_type or not content or not canonical_text:
+            continue
+        dedup_key = str(item.get("dedup_key") or "").strip()
+        if not dedup_key:
+            dedup_key = _stable_memory_dedup_key(
+                memory_type=memory_type,
+                canonical_text=canonical_text,
+            )
+        title = " ".join(str(item.get("title") or canonical_text).split()).strip()[:80]
+        evidence = item.get("evidence")
+        normalized_evidence = evidence if isinstance(evidence, list) else []
+        if not normalized_evidence:
+            normalized_evidence = [{"source": "leader_tool", "quote": content}]
+        candidates.append(
+            {
+                "action": str(item.get("action") or "ADD").strip().upper() or "ADD",
+                "memory_type": memory_type,
+                "title": title or canonical_text[:80],
+                "content": content,
+                "canonical_text": canonical_text,
+                "dedup_key": dedup_key,
+                "confidence": float(item.get("confidence") or 0.9),
+                "source_episode_uid": str(item.get("source_episode_uid") or ""),
+                "evidence": normalized_evidence,
+            }
+        )
+    if not candidates:
+        return []
+    return apply_memory_candidates(
+        uuid=uuid,
+        project_uid=project_uid,
+        session_uid=session_uid,
+        candidates=candidates,
+        db_name=db_name,
+    )

--- a/agent/memory/store.py
+++ b/agent/memory/store.py
@@ -2,8 +2,11 @@ from typing import Any
 
 from .repository import (
     ensure_memory_tables,
+    get_project_memory_episode,
     get_project_session_compact_memory,
+    list_project_memory_episodes,
     list_project_memory_items,
+    save_project_memory_episode,
     save_project_session_compact_memory,
     touch_memory_items,
     upsert_project_memory_item,
@@ -12,6 +15,9 @@ from .service import search_project_memory_items
 
 __all__ = [
     "ensure_memory_tables",
+    "save_project_memory_episode",
+    "get_project_memory_episode",
+    "list_project_memory_episodes",
     "get_project_session_compact_memory",
     "save_project_session_compact_memory",
     "upsert_project_memory_item",

--- a/agent/memory/store.py
+++ b/agent/memory/store.py
@@ -38,6 +38,8 @@ def query_long_term_memory(
     uuid: str,
     project_uid: str,
     query: str,
+    memory_type: str | None = None,
+    status: str | None = "active",
     limit: int = 5,
     db_name: str = "./database.sqlite",
 ) -> list[dict[str, Any]]:
@@ -45,6 +47,8 @@ def query_long_term_memory(
         uuid=uuid,
         project_uid=project_uid,
         query=query,
+        memory_type=memory_type,
+        status=status,
         limit=limit,
         db_name=db_name,
     )

--- a/agent/memory/store.py
+++ b/agent/memory/store.py
@@ -9,6 +9,7 @@ from .repository import (
     save_project_memory_episode,
     save_project_session_compact_memory,
     touch_memory_items,
+    update_memory_item_status,
     upsert_project_memory_item,
 )
 from .service import search_project_memory_items
@@ -21,6 +22,7 @@ __all__ = [
     "get_project_session_compact_memory",
     "save_project_session_compact_memory",
     "upsert_project_memory_item",
+    "update_memory_item_status",
     "list_project_memory_items",
     "touch_memory_items",
     "search_project_memory_items",

--- a/agent/paper_agent.py
+++ b/agent/paper_agent.py
@@ -10,6 +10,8 @@ from langchain_core.prompts import ChatPromptTemplate
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 from .runtime_agent import build_runtime_tools, create_runtime_agent
+from .memory.service import write_memory_from_leader
+from .memory.store import query_long_term_memory
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,10 @@ PAPER_QA_SYSTEM_PROMPT = """你是专业论文问答 Agent。
 [其他工具]
 - 需要总结/批判性阅读/方法比较/翻译时，可调用 use_skill
 - 生成思维导图时：调用 use_skill("mindmap", task)，然后直接输出 <mindmap>{{"name":"主题","children":[...]}}</mindmap>
+- 如需判断某条长期记忆是否已存在、是否冲突、是否需要更新，先调用 query_memory
+- 当你确认出现了稳定用户偏好、长期项目事实、或值得沉淀的知识结论时，可调用 write_memory
+- 在调用 write_memory 之前，优先先调用 query_memory 做查重或确认是否已有近似记忆
+- write_memory 只能写 declarative fragment statements，禁止写 Q/A 原文
 
 [复杂任务处理]
 仅当遇到明确的复杂多步骤任务时才使用计划工具（如文献综述、对比分析、系统性调研等）：
@@ -119,11 +125,37 @@ def create_paper_agent_session(
         scope_summary=scope_summary,
     )
 
+    write_memory_fn = None
+    query_memory_fn = None
+    if project_uid and session_uid and user_uuid:
+        def _query_memory(query: str, memory_type: str | None, limit: int) -> list[dict[str, Any]]:
+            return query_long_term_memory(
+                uuid=user_uuid,
+                project_uid=project_uid,
+                query=query,
+                memory_type=memory_type,
+                status="active",
+                limit=limit,
+            )
+
+        def _write_memory(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            return write_memory_from_leader(
+                uuid=user_uuid,
+                project_uid=project_uid,
+                session_uid=session_uid,
+                items=items,
+            )
+
+        query_memory_fn = _query_memory
+        write_memory_fn = _write_memory
+
     tools = build_runtime_tools(
         search_document_fn=search_document_fn,
         search_document_evidence_fn=search_document_evidence_fn,
         read_document_fn=read_document_fn,
         list_documents_fn=list_documents_fn,
+        query_memory_fn=query_memory_fn,
+        write_memory_fn=write_memory_fn,
     )
 
     tool_specs: list[dict[str, str]] = []

--- a/agent/runtime_agent.py
+++ b/agent/runtime_agent.py
@@ -12,12 +12,16 @@ def build_runtime_tools(
     search_document_evidence_fn: Callable[[str], dict[str, Any]] | None = None,
     read_document_fn: Callable[[int, int], tuple[str, int]] | None = None,
     list_documents_fn: Callable[[], list[dict[str, Any]]] | None = None,
+    query_memory_fn: Callable[[str, str | None, int], list[dict[str, Any]]] | None = None,
+    write_memory_fn: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
 ) -> list[Any]:
     return build_agent_tools(
         search_document_fn=search_document_fn,
         search_document_evidence_fn=search_document_evidence_fn,
         read_document_fn=read_document_fn,
         list_documents_fn=list_documents_fn,
+        query_memory_fn=query_memory_fn,
+        write_memory_fn=write_memory_fn,
     )
 
 

--- a/agent/tools/builder.py
+++ b/agent/tools/builder.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import Any
 
 from .document import build_list_document_tool, build_read_document_tool, build_search_document_tool
+from .memory import build_query_memory_tool, build_write_memory_tool
 from .paper_search import search_papers
 from .plan_tools import read_plan, write_plan
 from .skill import use_skill
@@ -42,6 +43,8 @@ def build_agent_tools(
     search_document_evidence_fn: Callable[[str], dict[str, Any]] | None = None,
     read_document_fn: Callable[[int, int], tuple[str, int]] | None = None,
     list_documents_fn: Callable[[], list[dict[str, Any]]] | None = None,
+    query_memory_fn: Callable[[str, str | None, int], list[dict[str, Any]]] | None = None,
+    write_memory_fn: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
 ):
     """构建 Agent 工具集"""
     runtime_tools: list[Any] = []
@@ -52,6 +55,10 @@ def build_agent_tools(
         runtime_tools.append(build_list_document_tool(list_documents_fn))
     if read_document_fn:
         runtime_tools.append(build_read_document_tool(read_document_fn, search_document_fn))
+    if query_memory_fn:
+        runtime_tools.append(build_query_memory_tool(query_memory_fn))
+    if write_memory_fn:
+        runtime_tools.append(build_write_memory_tool(write_memory_fn))
 
     # 静态工具(直接使用)
     runtime_tools.extend([search_web, search_papers, use_skill, write_plan, read_plan])

--- a/agent/tools/memory.py
+++ b/agent/tools/memory.py
@@ -1,0 +1,94 @@
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryWriteItemInput(BaseModel):
+    memory_type: str = Field(description="`user_memory` or `knowledge_memory`.")
+    content: str = Field(
+        description="Declarative long-term memory fragment statement. Never provide Q/A transcripts."
+    )
+    canonical_text: str = Field(
+        default="",
+        description="Canonical fragment statement used for dedup. Prefer the shortest stable form.",
+    )
+    title: str = Field(default="", description="Short label for the memory item.")
+    dedup_key: str = Field(
+        default="",
+        description="Optional stable slot key for updates, e.g. `user:response_style`.",
+    )
+    action: str = Field(default="ADD", description="ADD, UPDATE, DELETE, NONE, or SUPERSEDE.")
+    confidence: float = Field(default=0.9, description="Confidence between 0 and 1.")
+
+
+class WriteMemoryInput(BaseModel):
+    items: list[MemoryWriteItemInput] = Field(
+        description="Memory items to write via the canonical reconcile pipeline."
+    )
+
+
+class QueryMemoryInput(BaseModel):
+    query: str = Field(
+        description="Semantic query used to find possibly related long-term memories before writing or answering."
+    )
+    memory_type: str = Field(
+        default="",
+        description="Optional memory type filter, e.g. `user_memory` or `knowledge_memory`.",
+    )
+    limit: int = Field(default=5, description="Maximum number of memory items to return.")
+
+
+def build_query_memory_tool(
+    query_memory_fn: Callable[[str, str | None, int], list[dict[str, Any]]],
+) -> Any:
+    @tool(
+        "query_memory",
+        description=(
+            "Query existing long-term memory for the current user/project/session scope. "
+            "Use this before write_memory when you suspect a duplicate, update, or contradiction."
+        ),
+        args_schema=QueryMemoryInput,
+    )
+    def query_memory(query: str, memory_type: str = "", limit: int = 5) -> str:
+        normalized_query = str(query or "").strip()
+        normalized_memory_type = str(memory_type or "").strip() or None
+        normalized_limit = max(1, int(limit))
+        logger.info(
+            "tool.query_memory called: query_len=%s memory_type=%s limit=%s",
+            len(normalized_query),
+            normalized_memory_type or "-",
+            normalized_limit,
+        )
+        result = query_memory_fn(normalized_query, normalized_memory_type, normalized_limit)
+        logger.info("tool.query_memory success: results=%s", len(result))
+        return json.dumps({"results": result}, ensure_ascii=False)
+
+    return query_memory
+
+
+def build_write_memory_tool(
+    write_memory_fn: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+) -> Any:
+    @tool(
+        "write_memory",
+        description=(
+            "Persist durable long-term memory fragments for the current user/project/session. "
+            "Use this when you identify a stable user preference, project fact, or durable knowledge. "
+            "Each item must be a declarative fragment statement, not Q/A dialogue."
+        ),
+        args_schema=WriteMemoryInput,
+    )
+    def write_memory(items: list[MemoryWriteItemInput]) -> str:
+        normalized_items = [item.model_dump() for item in items]
+        logger.info("tool.write_memory called: items=%s", len(normalized_items))
+        result = write_memory_fn(normalized_items)
+        logger.info("tool.write_memory success: results=%s", len(result))
+        return json.dumps({"results": result}, ensure_ascii=False)
+
+    return write_memory

--- a/openspec/changes/redesign-agentic-memory-system/.openspec.yaml
+++ b/openspec/changes/redesign-agentic-memory-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-19

--- a/openspec/changes/redesign-agentic-memory-system/design.md
+++ b/openspec/changes/redesign-agentic-memory-system/design.md
@@ -1,0 +1,171 @@
+## Context
+
+当前项目的记忆系统由运行态消息缓存、会话摘要表和 `memory_items` 组成，但长期记忆的主链路仍然是“同步写入截断后的 `Q/A` 文本 + 关键词检索 + 字符串注入”。这导致长期记忆更像对话片段缓存，而不是可维护的知识层：
+
+- 写入发生在用户主链路上，任何扩展都直接增加回合延迟
+- 存储对象缺少 canonical form、证据、状态、去重键和替代关系
+- 用户偏好与知识事实混存，覆盖规则和冲突处理不清晰
+- 关键词主检索对同义改写、跨轮抽象和事实更新不稳定
+- 旧代码在 `agent/memory/*`、`utils/utils.py`、prompt 构造链路中分散，已与目标架构不一致
+
+项目已经具备 SQLite 持久化和异步任务队列基础设施，因此本次改造重点不是引入新层级，而是在现有边界内建立新的 canonical memory pipeline，并替换掉旧的同步片段写入与关键词主检索路径。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 将每轮对话后的长期记忆保存改为异步执行，避免阻塞主问答链路
+- 将长期记忆的主存储形态从聊天片段改为结构化 memory item
+- 区分用户记忆与知识记忆，并为两类记忆定义不同的更新和注入规则
+- 为长期记忆提供 reconcile 机制，支持新增、更新、删除、跳过和替代
+- 引入可追溯的数据模型，保留 raw episode 与 evidence 关联
+- 替换并移除旧的同步片段写入、关键词主检索和无语义 facade 入口
+
+**Non-Goals:**
+- 不在本次变更中引入外部专用 memory service
+- 不将整个系统重构为图数据库或完整知识图谱方案
+- 不追求一次迁移所有历史数据为高质量结构化记忆
+- 不改变短期会话消息缓存与中期 compact summary 的基本职责
+
+## Decisions
+
+### Decision 1: 采用 “episode + memory item + evidence” 三段式长期记忆模型
+
+**选择:** 将长期记忆拆为原始 episode、结构化 memory item 和 evidence/link 关系，而不是继续把 `Q/A` 文本直接当长期记忆主体。
+
+**理由:**
+- episode 层负责审计、回放和重新抽取
+- memory item 层负责检索、注入和状态管理
+- evidence 层负责建立记忆与原始来源之间的可追溯关系
+- 这种结构能支持后续去重、替代和误提取修复
+
+**备选方案:**
+- 继续扩展单表 `memory_items`: 简单，但会把事件日志、知识条目和注入对象混成一层，后续维护成本高
+- 只保存结构化 memory item，不保留原始 episode: 实现更轻，但丢失回溯与重算能力
+
+### Decision 2: 使用专用异步 memory writer worker，而不是复用主对话 leader agent
+
+**选择:** 每轮对话完成后落 raw episode，并投递专用 memory writer 任务；由 worker 读取本轮对话和必要上下文，输出结构化 memory candidates。
+
+**理由:**
+- memory 保存职责与主问答职责不同，分离后更便于测试、限流和失败重试
+- 专用 worker 的输入输出边界更稳定，避免复用大而全的对话 agent
+- 项目已有 `utils/task_queue.py` 与 worker 任务模式，可直接复用
+
+**备选方案:**
+- 在主链路同步保存记忆: 实现简单，但直接增加用户时延
+- 复用 leader agent 二次运行: 上下文更重、成本更高，行为也更难约束
+
+### Decision 3: 长期记忆按类型拆分为 user memory 和 knowledge memory
+
+**选择:** 定义至少两类顶层记忆类型：
+- `user_memory`: 偏好、格式要求、长期指令
+- `knowledge_memory`: 论文事实、项目事实、可引用结论
+
+**理由:**
+- 用户记忆默认“最新有效”，允许覆盖和替代
+- 知识记忆必须带 evidence，并对冲突保持审慎，不适合简单覆盖
+- 检索和 prompt 注入对两类记忆的需求不同
+
+**备选方案:**
+- 单一 memory_kind + 统一规则: 实现最省事，但生命周期和冲突策略会混乱
+- 进一步细分为更多类型: 更精细，但首轮改造复杂度高，可在后续演进
+
+### Decision 4: reconcile 采用动作驱动模型，而不是直接 upsert
+
+**选择:** memory worker 在写入前必须对候选记忆执行 reconcile，动作集合为 `ADD`、`UPDATE`、`DELETE`、`NONE`、`SUPERSEDE`。
+
+**理由:**
+- 去重不是唯一问题，更关键的是“旧事实是否被新事实替代”
+- 同一偏好、同一知识点可能出现更新和冲突，简单 upsert 不足以表达状态变化
+- 动作驱动模型更适合测试和审计
+
+**备选方案:**
+- 仅靠 `dedup_key` 精确去重: 无法处理近似重复和事实替代
+- 纯 LLM 自由写入: 无法提供稳定生命周期与幂等保证
+
+### Decision 5: 检索改为类型化过滤 + 语义召回优先，关键词仅作降级
+
+**选择:** 长期记忆的 canonical 检索路径改为：
+- `user_memory`: 高优先级 active profile 直接加载或轻量过滤
+- `knowledge_memory`: 基于 metadata filter 的语义召回，必要时再 rerank
+- 关键词匹配仅作为兼容降级策略，不再作为主检索算法
+
+**理由:**
+- 用户偏好不需要每次全文搜索
+- 知识记忆必须解决同义改写和抽象表达问题
+- 兼容降级可以降低迁移风险
+
+**备选方案:**
+- 保留关键词检索为主: 不能满足长期记忆质量要求
+- 全量改成图检索: 架构收益存在，但本次范围过大
+
+### Decision 6: Prompt 注入按记忆类型分流，并显式退役旧注入方式
+
+**选择:**
+- `user_memory` 注入到 system/policy 侧，作为行为约束
+- `knowledge_memory` 注入到 context 侧，附带 evidence 优先规则
+- 现有“将所有长期记忆拼成一段文本”的主链路注入方式退役
+
+**理由:**
+- 用户偏好和知识证据在 prompt 中的语义角色不同
+- 分流后更容易控制长度、优先级和冲突处理
+- 可以让旧的 `inject_long_term_memory` 与关键词结果拼接逻辑退出主链路
+
+**备选方案:**
+- 继续统一拼接成 `[长期记忆]` 段落: 迁移成本低，但表达能力和可控性差
+
+### Decision 7: 老代码采用“替换后删除”的治理策略，而不是长期双写双读
+
+**选择:** 新 pipeline 达到可用后，移除旧的同步片段写入、关键词主检索和仅做转发的 facade；仅在短期迁移窗口内保留必要兼容读取。
+
+**理由:**
+- 项目已有明确约束：不长期保留历史兼容 facade 和无独立语义的 wrapper
+- 双主链路会让行为不确定，测试与文档也会持续分裂
+- 长期 memory 系统必须存在单一 canonical 入口
+
+**备选方案:**
+- 长期双写双读: 回滚轻松，但会让技术债长期固化
+- 立即硬切删除所有旧路径: 风险过高，不利于平滑验证
+
+## Risks / Trade-offs
+
+- [异步任务失败导致记忆缺失] → 为 memory job 增加任务状态、重试和幂等写入约束，并允许后续补偿重跑
+- [结构化抽取质量不稳定] → 对 memory writer 输出建立 schema 校验、低置信度丢弃和 evidence 必填规则
+- [旧数据与新模型并存期间语义不一致] → 明确迁移窗口内的兼容读取边界，并禁止继续沿用旧写入主链路
+- [语义检索引入额外依赖和成本] → 优先复用项目已有 embedding 能力，关键词检索仅作为受控降级
+- [去重与替代逻辑过于复杂] → 先支持最关键的动作集合和两类顶层记忆，避免首版过度抽象
+- [清理老代码时引发回归] → 为旧路径退役补充回归测试和文档更新，按模块逐步删除而非一次性大改
+
+## Migration Plan
+
+### Phase 1: 数据模型和事件落盘
+1. 新增 episode、memory item、evidence 所需表或字段
+2. 将当前对话完成后的同步 `persist_turn_memory` 改为 raw episode 持久化
+3. 在对话完成后投递异步 memory writer job
+
+### Phase 2: 异步抽取与 reconcile
+1. 实现 memory writer worker 输入/输出 schema
+2. 实现 user memory 与 knowledge memory 的候选抽取
+3. 实现 dedup key、近似匹配、状态迁移和 supersede 逻辑
+
+### Phase 3: 检索与 prompt 注入切换
+1. 将 controller 的长期记忆检索切到 typed retrieval
+2. 将 prompt 注入改为 user memory / knowledge memory 分流
+3. 将关键词检索降级为非主路径 fallback
+
+### Phase 4: 旧代码退役
+1. 删除旧的同步片段写入逻辑
+2. 删除关键词主检索与旧注入主路径
+3. 清理 `store` / `utils` 中无独立语义的 memory facade
+4. 更新 README、架构说明和测试
+
+### Rollback 策略
+- 保留数据库迁移的向后兼容读取能力
+- 在切换期通过 feature flag 或配置开关临时回退到旧读取链路
+- 若异步 worker 稳定性不足，可先保留 raw episode 落盘并暂停结构化写入步骤
+
+## Open Questions
+
+- 初版语义召回是直接复用现有 embedding 组件，还是单独为 memory item 建立更轻量的向量索引
+- 是否需要为用户提供显式的记忆查看、删除和禁用入口
+- 历史 `memory_items` 是否做离线迁移，还是仅保留只读兼容并让新数据走新模型

--- a/openspec/changes/redesign-agentic-memory-system/proposal.md
+++ b/openspec/changes/redesign-agentic-memory-system/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+当前项目的长期记忆仍以截断后的 `Q/A` 文本片段为主存储形态，并通过关键词重叠与时间衰减进行检索。这种实现无法稳定支持用户偏好、论文事实、项目知识等长期记忆场景，也缺少结构化更新、冲突处理和可靠去重能力。
+
+随着项目向多 Agent、长会话和项目级知识沉淀演进，记忆系统需要从“对话片段缓存”升级为“异步、结构化、可对账的长期记忆管线”，避免主链路阻塞，并让记忆具备可追溯、可更新、可检索的工程属性。
+
+## What Changes
+
+- 将现有同步 `persist_turn_memory` 逻辑改造为“原始 episode 落盘 + 异步 memory job 投递”的双阶段流程
+- 新增长期记忆结构化抽取流程，区分用户偏好/指令类记忆与知识类记忆
+- 新增记忆对账与生命周期动作，支持 `ADD`、`UPDATE`、`DELETE`、`NONE`、`SUPERSEDE`
+- 为长期记忆补充 canonical text、dedup key、evidence、confidence、status 等结构化字段
+- 将长期记忆检索从关键词优先改为类型化检索与语义召回优先
+- 调整 prompt 注入策略，对用户记忆与知识记忆采用不同注入位置与优先级
+- 替换并移除旧的同步片段写入、关键词主检索与仅透传式兼容入口，避免新旧主链路长期并存
+- **BREAKING**: 长期记忆的主链路语义将从“聊天片段存储/搜索”切换为“结构化 memory item 管理/检索”
+
+## Capabilities
+
+### New Capabilities
+
+- `agentic-memory-system`: 定义长期记忆的异步抽取、结构化存储、去重对账、状态迁移与类型化检索能力
+
+### Modified Capabilities
+
+<!-- 无现有 capability 需要修改 -->
+
+## Impact
+
+**代码影响**:
+- `agent/application/agent_center/memory.py` - 从同步对话片段写入切换到 episode 持久化与异步任务投递
+- `agent/application/agent_center/page_orchestrator.py` - 对话完成后触发 memory pipeline
+- `agent/memory/repository.py` - 扩展记忆表结构，新增 episode / evidence / lifecycle 支持
+- `agent/memory/service.py` - 重构长期记忆检索与对账逻辑
+- `agent/memory/store.py` / `utils/utils.py` - 清理旧的 memory facade 与兼容入口
+- `agent/application/agent_center/controller.py` - 按记忆类型调整 prompt 注入策略
+- `utils/task_queue.py` / `utils/tasks.py` - 新增异步 memory writer 任务
+
+**数据影响**:
+- 新增长期记忆相关结构化字段与原始 episode 数据
+- 现有 `memory_items` 数据模型需要迁移或兼容读取
+- 记忆检索索引和 dedup key 需要持久化维护
+
+**依赖与运行时影响**:
+- 复用现有异步任务基础设施，不要求新增外部队列服务
+- 需要引入或复用 embedding / rerank 能力支撑语义召回
+- 异步 memory job 的失败、重试、幂等需要纳入运行时治理

--- a/openspec/changes/redesign-agentic-memory-system/specs/agentic-memory-system/spec.md
+++ b/openspec/changes/redesign-agentic-memory-system/specs/agentic-memory-system/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Completed turns SHALL persist raw episodes and enqueue background memory extraction
+
+系统必须在一轮对话完成后先持久化原始 memory episode，再异步投递长期记忆抽取任务。长期记忆保存不得阻塞用户主问答返回。
+
+#### Scenario: Assistant turn completes successfully
+- **WHEN** 系统完成一轮用户问题与 assistant 回复并准备写入长期记忆
+- **THEN** 系统必须先保存该轮原始 episode 数据
+- **THEN** 系统必须异步投递一个 memory extraction job
+- **THEN** 用户主链路不得等待 memory extraction 完成
+
+#### Scenario: Memory extraction job retries after transient failure
+- **WHEN** 异步 memory extraction job 因临时错误失败
+- **THEN** 系统必须允许基于已保存的 raw episode 重试该任务
+- **THEN** 重试写入不得产生重复的 active memory item
+
+### Requirement: Long-term memory SHALL distinguish user memory from knowledge memory
+
+系统必须将长期记忆至少区分为 user memory 与 knowledge memory，并为两类记忆保存结构化字段，而不是仅保存聊天片段文本。
+
+#### Scenario: User preference is extracted
+- **WHEN** 本轮对话包含稳定的用户偏好、格式要求或长期指令
+- **THEN** 系统必须将其保存为 user memory
+- **THEN** 该记忆必须包含 canonical text、status、confidence 和来源 episode
+
+#### Scenario: Knowledge fact is extracted
+- **WHEN** 本轮对话包含论文事实、项目事实或可引用结论
+- **THEN** 系统必须将其保存为 knowledge memory
+- **THEN** 该记忆必须包含 canonical text、evidence、status、confidence 和来源 episode
+
+### Requirement: Memory writes SHALL reconcile against existing memories before persistence
+
+系统必须在持久化长期记忆前，对候选记忆与已有 active memory 执行 reconcile，并明确产生 `ADD`、`UPDATE`、`DELETE`、`NONE` 或 `SUPERSEDE` 动作。
+
+#### Scenario: Duplicate memory candidate matches existing active memory
+- **WHEN** 候选记忆与现有 active memory 在 dedup key 或 canonical identity 上匹配
+- **THEN** 系统不得创建新的重复 active memory item
+- **THEN** 系统必须执行 `UPDATE` 或 `NONE`
+
+#### Scenario: New user instruction replaces old instruction
+- **WHEN** 新的 user memory 与旧的 active user memory 指向同一偏好槽位但值发生变化
+- **THEN** 系统必须将旧记忆标记为 superseded 或 inactive
+- **THEN** 系统必须将新记忆作为当前 active 版本保存
+
+#### Scenario: New evidence supersedes old knowledge memory
+- **WHEN** 新的 knowledge memory 与旧的 active knowledge memory 冲突且新证据被接受
+- **THEN** 系统必须保留新旧关系而不是简单并存为两个无关 active 记忆
+- **THEN** 系统必须记录 supersede 或 equivalent lifecycle 信息
+
+### Requirement: Long-term memory retrieval SHALL use typed retrieval with semantic recall as the canonical path
+
+系统必须将长期记忆检索的主路径改为类型化过滤与语义召回。关键词匹配只能作为受控降级路径，不能继续作为长期记忆的主检索算法。
+
+#### Scenario: User memory is loaded for prompt policy context
+- **WHEN** 系统为一次新请求构建 prompt
+- **THEN** active user memory 必须按类型和状态过滤后加载
+- **THEN** 该类记忆不得依赖关键词全文检索才能生效
+
+#### Scenario: Knowledge memory is recalled for a semantically related query
+- **WHEN** 用户查询与已有 knowledge memory 语义相关但不共享显式关键词
+- **THEN** 系统必须能够通过语义召回返回相关 active knowledge memory
+
+#### Scenario: Rejected or superseded memories are excluded
+- **WHEN** 系统执行长期记忆检索
+- **THEN** 被标记为 rejected、deleted 或 superseded 的记忆不得作为默认注入结果返回
+
+### Requirement: Prompt construction SHALL inject user memory and knowledge memory through separate channels
+
+系统必须将 user memory 和 knowledge memory 以不同的 prompt 通道注入，保证行为约束与证据上下文分离。
+
+#### Scenario: User memory influences response style
+- **WHEN** 存在 active user memory 指定语言、格式或回答偏好
+- **THEN** 系统必须将该记忆注入到 system 或 policy 语义位置
+
+#### Scenario: Knowledge memory remains subordinate to current evidence
+- **WHEN** active knowledge memory 被注入到 prompt
+- **THEN** 系统必须明确当前问题与当前证据优先于长期 knowledge memory
+
+### Requirement: The new memory pipeline SHALL replace and retire the legacy memory path
+
+系统必须将新的异步结构化记忆 pipeline 作为唯一 canonical 长期记忆主链路，并替换、删除或降级旧的同步片段写入与关键词主检索代码。
+
+#### Scenario: Legacy synchronous Q/A fragment persistence is retired
+- **WHEN** 一轮对话结束并触发长期记忆保存
+- **THEN** 系统不得再以同步方式将截断后的 `Q/A` 文本直接作为 canonical 长期记忆写入
+
+#### Scenario: Legacy keyword search is not used as the default long-term memory retrieval path
+- **WHEN** 系统为主 prompt 构建长期记忆上下文
+- **THEN** 系统不得默认使用旧的关键词打分路径作为 canonical 检索实现
+
+#### Scenario: Legacy facade layers do not remain as canonical entrypoints
+- **WHEN** 新的长期记忆 pipeline 上线
+- **THEN** 无独立语义的兼容 wrapper 和 facade 必须被删除，或明确降级为非主路径兼容接口

--- a/openspec/changes/redesign-agentic-memory-system/tasks.md
+++ b/openspec/changes/redesign-agentic-memory-system/tasks.md
@@ -8,10 +8,10 @@
 ## 2. Async Memory Writer And Reconcile Logic
 
 - [x] 2.1 Add a dedicated async memory writer task that reads a saved episode and bounded context from the repository layer
-- [ ] 2.2 Implement structured candidate extraction for user memory and knowledge memory with validated output schema
-- [ ] 2.3 Implement reconcile actions (`ADD`, `UPDATE`, `DELETE`, `NONE`, `SUPERSEDE`) against existing active memories
-- [ ] 2.4 Implement lifecycle transitions for superseded, rejected, deleted, and active memory items with evidence preservation
-- [ ] 2.5 Add retry-safe and idempotent write behavior for memory jobs so repeated execution does not create duplicate active memories
+- [x] 2.2 Implement structured candidate extraction for user memory and knowledge memory with validated output schema
+- [x] 2.3 Implement reconcile actions (`ADD`, `UPDATE`, `DELETE`, `NONE`, `SUPERSEDE`) against existing active memories
+- [x] 2.4 Implement lifecycle transitions for superseded, rejected, deleted, and active memory items with evidence preservation
+- [x] 2.5 Add retry-safe and idempotent write behavior for memory jobs so repeated execution does not create duplicate active memories
 
 ## 3. Retrieval And Prompt Injection Cutover
 
@@ -29,7 +29,7 @@
 
 ## 5. Verification, Migration, And Documentation
 
-- [ ] 5.1 Add unit tests for episode persistence, candidate extraction normalization, reconcile actions, lifecycle transitions, and dedup behavior
+- [x] 5.1 Add unit tests for episode persistence, candidate extraction normalization, reconcile actions, lifecycle transitions, and dedup behavior
 - [ ] 5.2 Add integration tests covering async memory job execution, typed retrieval, prompt injection, and legacy-path retirement
 - [ ] 5.3 Add migration coverage for existing memory data compatibility and rollback-safe reads during the transition window
 - [ ] 5.4 Update README and architecture docs to describe the new async agentic memory pipeline and removed legacy behavior

--- a/openspec/changes/redesign-agentic-memory-system/tasks.md
+++ b/openspec/changes/redesign-agentic-memory-system/tasks.md
@@ -1,0 +1,35 @@
+## 1. Data Model And Episode Pipeline
+
+- [x] 1.1 Design and migrate SQLite schema for raw memory episodes, structured memory items, and evidence links
+- [x] 1.2 Add repository-layer read/write APIs for episodes, typed memory items, lifecycle state, and evidence metadata
+- [x] 1.3 Replace the current synchronous turn-memory persistence entrypoint so completed turns persist raw episodes instead of canonical `Q/A` fragments
+- [x] 1.4 Add stable dedup-related fields and indexes such as canonical text identity, dedup key, and active-status filtering
+
+## 2. Async Memory Writer And Reconcile Logic
+
+- [x] 2.1 Add a dedicated async memory writer task that reads a saved episode and bounded context from the repository layer
+- [ ] 2.2 Implement structured candidate extraction for user memory and knowledge memory with validated output schema
+- [ ] 2.3 Implement reconcile actions (`ADD`, `UPDATE`, `DELETE`, `NONE`, `SUPERSEDE`) against existing active memories
+- [ ] 2.4 Implement lifecycle transitions for superseded, rejected, deleted, and active memory items with evidence preservation
+- [ ] 2.5 Add retry-safe and idempotent write behavior for memory jobs so repeated execution does not create duplicate active memories
+
+## 3. Retrieval And Prompt Injection Cutover
+
+- [ ] 3.1 Replace keyword-first long-term memory lookup with typed retrieval for active user memory and semantic recall for knowledge memory
+- [ ] 3.2 Refactor prompt construction so user memory is injected through policy/system context and knowledge memory through evidence-aware context
+- [ ] 3.3 Add controlled fallback behavior for degraded retrieval without keeping the old keyword path as the canonical implementation
+- [ ] 3.4 Ensure rejected, deleted, and superseded memories are excluded from default prompt injection
+
+## 4. Legacy Path Retirement
+
+- [ ] 4.1 Remove the old synchronous fragment-writing flow that stores truncated `Q/A` text as canonical long-term memory
+- [ ] 4.2 Remove or demote the old keyword-scoring retrieval path so it is no longer the default long-term memory search implementation
+- [ ] 4.3 Delete legacy memory wrappers and facade exports that only forward calls without preserving a necessary boundary
+- [ ] 4.4 Update call sites to use the new canonical repository/service entrypoints instead of legacy memory helpers
+
+## 5. Verification, Migration, And Documentation
+
+- [ ] 5.1 Add unit tests for episode persistence, candidate extraction normalization, reconcile actions, lifecycle transitions, and dedup behavior
+- [ ] 5.2 Add integration tests covering async memory job execution, typed retrieval, prompt injection, and legacy-path retirement
+- [ ] 5.3 Add migration coverage for existing memory data compatibility and rollback-safe reads during the transition window
+- [ ] 5.4 Update README and architecture docs to describe the new async agentic memory pipeline and removed legacy behavior

--- a/openspec/changes/redesign-agentic-memory-system/tasks.md
+++ b/openspec/changes/redesign-agentic-memory-system/tasks.md
@@ -15,21 +15,21 @@
 
 ## 3. Retrieval And Prompt Injection Cutover
 
-- [ ] 3.1 Replace keyword-first long-term memory lookup with typed retrieval for active user memory and semantic recall for knowledge memory
-- [ ] 3.2 Refactor prompt construction so user memory is injected through policy/system context and knowledge memory through evidence-aware context
-- [ ] 3.3 Add controlled fallback behavior for degraded retrieval without keeping the old keyword path as the canonical implementation
-- [ ] 3.4 Ensure rejected, deleted, and superseded memories are excluded from default prompt injection
+- [x] 3.1 Replace keyword-first long-term memory lookup with typed retrieval for active user memory and semantic recall for knowledge memory
+- [x] 3.2 Refactor prompt construction so user memory is injected through policy/system context and knowledge memory through evidence-aware context
+- [x] 3.3 Add controlled fallback behavior for degraded retrieval without keeping the old keyword path as the canonical implementation
+- [x] 3.4 Ensure rejected, deleted, and superseded memories are excluded from default prompt injection
 
 ## 4. Legacy Path Retirement
 
-- [ ] 4.1 Remove the old synchronous fragment-writing flow that stores truncated `Q/A` text as canonical long-term memory
-- [ ] 4.2 Remove or demote the old keyword-scoring retrieval path so it is no longer the default long-term memory search implementation
-- [ ] 4.3 Delete legacy memory wrappers and facade exports that only forward calls without preserving a necessary boundary
-- [ ] 4.4 Update call sites to use the new canonical repository/service entrypoints instead of legacy memory helpers
+- [x] 4.1 Remove the old synchronous fragment-writing flow that stores truncated `Q/A` text as canonical long-term memory
+- [x] 4.2 Remove or demote the old keyword-scoring retrieval path so it is no longer the default long-term memory search implementation
+- [x] 4.3 Delete legacy memory wrappers and facade exports that only forward calls without preserving a necessary boundary
+- [x] 4.4 Update call sites to use the new canonical repository/service entrypoints instead of legacy memory helpers
 
 ## 5. Verification, Migration, And Documentation
 
 - [x] 5.1 Add unit tests for episode persistence, candidate extraction normalization, reconcile actions, lifecycle transitions, and dedup behavior
-- [ ] 5.2 Add integration tests covering async memory job execution, typed retrieval, prompt injection, and legacy-path retirement
-- [ ] 5.3 Add migration coverage for existing memory data compatibility and rollback-safe reads during the transition window
-- [ ] 5.4 Update README and architecture docs to describe the new async agentic memory pipeline and removed legacy behavior
+- [x] 5.2 Add integration tests covering async memory job execution, typed retrieval, prompt injection, and legacy-path retirement
+- [x] 5.3 Add migration coverage for existing memory data compatibility and rollback-safe reads during the transition window
+- [x] 5.4 Update README and architecture docs to describe the new async agentic memory pipeline and removed legacy behavior

--- a/tests/integration/test_agentic_memory_pipeline.py
+++ b/tests/integration/test_agentic_memory_pipeline.py
@@ -80,9 +80,9 @@ def test_persist_turn_memory_runs_agentic_memory_pipeline(monkeypatch, tmp_path)
                 }
             return SimpleNamespace(content=json.dumps(body, ensure_ascii=False))
 
-    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
-    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
-    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid, db_name="./database.sqlite": f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid, db_name="./database.sqlite": "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid, db_name="./database.sqlite": "https://example.test")
     monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
     monkeypatch.chdir(tmp_path)
     init_database("./database.sqlite")

--- a/tests/integration/test_agentic_memory_pipeline.py
+++ b/tests/integration/test_agentic_memory_pipeline.py
@@ -1,0 +1,178 @@
+import time
+from types import SimpleNamespace
+import json
+
+from agent.adapters.sqlite.project_repository import ensure_default_project_for_user, ensure_default_project_session
+from agent.application.agent_center.controller import build_hinted_prompt
+from agent.application.agent_center.memory import persist_turn_memory
+from agent.memory.store import (
+    list_project_memory_episodes,
+    list_project_memory_items,
+    query_long_term_memory,
+)
+from utils.task_queue import get_task_status_by_uid
+import utils.utils as legacy_utils
+from utils.utils import ensure_local_user, init_database
+
+
+def _wait_for_memory_items(
+    *,
+    uuid: str,
+    project_uid: str,
+    expected_count: int,
+    db_name: str,
+) -> list[dict[str, object]]:
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        items = list_project_memory_items(
+            uuid=uuid,
+            project_uid=project_uid,
+            status="active",
+            limit=10,
+            db_name=db_name,
+        )
+        if len(items) >= expected_count:
+            return items
+        time.sleep(0.05)
+    return list_project_memory_items(
+        uuid=uuid,
+        project_uid=project_uid,
+        status="active",
+        limit=10,
+        db_name=db_name,
+    )
+
+
+def test_persist_turn_memory_runs_agentic_memory_pipeline(monkeypatch, tmp_path) -> None:
+    class _FakeModel:
+        def invoke(self, messages):
+            payload = json.loads(messages[1][1])
+            current_prompt = str(payload["episode"]["prompt"])
+            if "中文项目符号" in current_prompt:
+                body = {
+                    "candidates": [
+                        {
+                            "action": "ADD",
+                            "memory_type": "user_memory",
+                            "title": "回答偏好",
+                            "content": "以后默认用中文项目符号回答",
+                            "canonical_text": "默认用中文项目符号回答",
+                            "dedup_key": "user:response_preferences",
+                            "confidence": 0.9,
+                            "evidence": [{"quote": "请记住，以后默认用中文项目符号回答"}],
+                        }
+                    ]
+                }
+            else:
+                body = {
+                    "candidates": [
+                        {
+                            "action": "ADD",
+                            "memory_type": "knowledge_memory",
+                            "title": "主要结论",
+                            "content": "主要结论是方法A在该任务上优于方法B。",
+                            "canonical_text": "方法A在该任务上优于方法B",
+                            "dedup_key": "knowledge:main-finding",
+                            "confidence": 0.84,
+                            "evidence": [{"quote": "主要结论是方法A在该任务上优于方法B。"}],
+                        }
+                    ]
+                }
+            return SimpleNamespace(content=json.dumps(body, ensure_ascii=False))
+
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
+    monkeypatch.chdir(tmp_path)
+    init_database("./database.sqlite")
+    ensure_local_user("local-user", db_name="./database.sqlite")
+    project_uid = ensure_default_project_for_user(
+        "local-user",
+        db_name="./database.sqlite",
+        sync_existing_files=False,
+    )
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name="./database.sqlite",
+    )
+
+    persist_turn_memory(
+        user_uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住，以后默认用中文项目符号回答",
+        answer="收到，后续默认用中文项目符号回答。",
+    )
+    persist_turn_memory(
+        user_uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="这篇论文的主要结论是什么？",
+        answer="主要结论是方法A在该任务上优于方法B。",
+    )
+
+    episodes = list_project_memory_episodes(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        limit=5,
+        db_name="./database.sqlite",
+    )
+    assert len(episodes) == 2
+
+    task_info = get_task_status_by_uid(
+        episodes[0]["episode_uid"],
+        "memory_writer",
+        db_name="./database.sqlite",
+    )
+    items = _wait_for_memory_items(
+        uuid="local-user",
+        project_uid=project_uid,
+        db_name="./database.sqlite",
+        expected_count=2,
+    )
+    user_items = query_long_term_memory(
+        uuid="local-user",
+        project_uid=project_uid,
+        query="",
+        memory_type="user_memory",
+        status="active",
+        limit=5,
+        db_name="./database.sqlite",
+    )
+    knowledge_items = query_long_term_memory(
+        uuid="local-user",
+        project_uid=project_uid,
+        query="主要结论",
+        memory_type="knowledge_memory",
+        status="active",
+        limit=5,
+        db_name="./database.sqlite",
+    )
+    hinted_prompt = build_hinted_prompt(
+        prompt="请基于已有结论继续分析",
+        compact_summary="用户持续关注论文结论",
+        user_uuid="local-user",
+        project_uid=project_uid,
+        detect_language_fn=lambda _text: "zh",
+        with_language_hint_fn=lambda text, _detector: f"{text} 中文回答",
+        search_project_memory_items_fn=query_long_term_memory,
+        inject_long_term_memory_fn=lambda text, _memories: text,
+        memory_limit=4,
+    )
+
+    assert task_info is not None
+    assert task_info["status"] in {"queued", "started", "finished"}
+    assert len(items) == 2
+    assert {str(item["memory_type"]) for item in items} == {"user_memory", "knowledge_memory"}
+    assert len(user_items) == 1
+    assert "项目符号" in str(user_items[0]["canonical_text"])
+    assert len(knowledge_items) == 1
+    assert "方法A" in str(knowledge_items[0]["canonical_text"])
+    assert "\nP:user_memory:" in hinted_prompt
+    assert "中文项目符号" in hinted_prompt
+    assert "\nM:knowledge_memory:" in hinted_prompt
+    assert "方法A在该任务上优于方法B" in hinted_prompt
+    assert not hasattr(legacy_utils, "search_project_memory_items")

--- a/tests/unit/test_agent_center_controller.py
+++ b/tests/unit/test_agent_center_controller.py
@@ -42,7 +42,15 @@ def test_load_scope_docs_with_text_and_cache_caption():
 
 
 def test_build_hinted_prompt_and_runtime_helpers():
-    memories = [{"memory_type": "semantic", "content": "m1"}]
+    def fake_search(**kwargs):
+        if kwargs["memory_type"] == "user_memory":
+            assert kwargs["status"] == "active"
+            return [{"memory_type": "user_memory", "content": "pref-zh"}]
+        if kwargs["memory_type"] == "knowledge_memory":
+            assert kwargs["status"] == "active"
+            return [{"memory_type": "knowledge_memory", "content": "fact-a"}]
+        return []
+
     hinted = build_hinted_prompt(
         prompt="hello",
         compact_summary="summary",
@@ -50,14 +58,15 @@ def test_build_hinted_prompt_and_runtime_helpers():
         project_uid="p1",
         detect_language_fn=lambda _text: "en",
         with_language_hint_fn=lambda text, _detector: f"{text}::lang",
-        search_project_memory_items_fn=lambda **_kwargs: memories,
+        search_project_memory_items_fn=fake_search,
         inject_long_term_memory_fn=lambda text, mem: f"{text}::{len(mem)}",
         memory_limit=4,
     )
     assert hinted.startswith("CTXv1\n")
     assert "\nI:sys=paper_qa,col=a2a,tools=-,skills=-\n" in hinted
+    assert "\nP:user_memory:pref-zh\n" in hinted
     assert "\nS:summary\n" in hinted
-    assert "\nM:semantic:m1\n" in hinted
+    assert "\nM:knowledge_memory:fact-a\n" in hinted
     assert "\nL:lang\n" in hinted
     assert hinted.endswith("\nQ:hello")
     assert resolve_runtime_session_id({"configurable": {"thread_id": "tid"}}) == "tid"

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -73,6 +73,34 @@ def _create_legacy_db_without_memory_expires_at(db_path: Path) -> None:
     conn.close()
 
 
+def _create_legacy_db_without_agentic_memory_columns(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE memory_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_uid TEXT UNIQUE NOT NULL,
+            uuid TEXT NOT NULL,
+            project_uid TEXT NOT NULL,
+            session_uid TEXT,
+            memory_type TEXT NOT NULL,
+            title TEXT DEFAULT '',
+            content TEXT NOT NULL,
+            source_prompt TEXT DEFAULT '',
+            source_answer TEXT DEFAULT '',
+            access_count INTEGER DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_accessed_at TEXT,
+            expires_at TEXT DEFAULT ''
+        )
+    """
+    )
+    conn.commit()
+    conn.close()
+
+
 def test_init_database_migrates_legacy_files_table(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy.sqlite"
     _create_legacy_db_without_files_uuid(db_path)
@@ -150,3 +178,38 @@ def test_init_database_migrates_legacy_memory_items_expires_at(tmp_path: Path) -
 
     assert "expires_at" in column_names
     assert idx_exists
+
+
+def test_init_database_migrates_agentic_memory_tables_and_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy_agentic_memory.sqlite"
+    _create_legacy_db_without_agentic_memory_columns(db_path)
+
+    init_database(str(db_path))
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(memory_items)")
+    column_names = [row[1] for row in cursor.fetchall()]
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_episodes'"
+    )
+    has_episode_table = cursor.fetchone() is not None
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_item_evidence'"
+    )
+    has_evidence_table = cursor.fetchone() is not None
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memory_items_active_lookup'"
+    )
+    has_active_index = cursor.fetchone() is not None
+    conn.close()
+
+    assert "canonical_text" in column_names
+    assert "dedup_key" in column_names
+    assert "status" in column_names
+    assert "confidence" in column_names
+    assert "source_episode_uid" in column_names
+    assert "evidence_json" in column_names
+    assert has_episode_table
+    assert has_evidence_table
+    assert has_active_index

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -1,6 +1,7 @@
 import sqlite3
 from pathlib import Path
 
+from agent.memory.store import query_long_term_memory
 from utils.page_helpers import check_api_key_configured
 from utils.utils import (
     ensure_local_user,
@@ -213,3 +214,42 @@ def test_init_database_migrates_agentic_memory_tables_and_columns(tmp_path: Path
     assert has_episode_table
     assert has_evidence_table
     assert has_active_index
+
+
+def test_legacy_memory_items_remain_readable_via_typed_query_after_migration(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "legacy_readable.sqlite"
+    _create_legacy_db_without_agentic_memory_columns(db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO memory_items (
+            memory_uid, uuid, project_uid, session_uid, memory_type, title, content,
+            source_prompt, source_answer, access_count, created_at, updated_at, last_accessed_at, expires_at
+        )
+        VALUES (
+            'm1', 'local-user', 'project-1', 'session-1', 'knowledge_memory', '结论',
+            '方法A优于方法B', '', '', 0, '2026-03-01 00:00:00', '2026-03-01 00:00:00', '', ''
+        )
+    """
+    )
+    conn.commit()
+    conn.close()
+
+    init_database(str(db_path))
+
+    items = query_long_term_memory(
+        uuid="local-user",
+        project_uid="project-1",
+        query="结论",
+        memory_type="knowledge_memory",
+        status="active",
+        limit=5,
+        db_name=str(db_path),
+    )
+
+    assert len(items) == 1
+    assert items[0]["content"] == "方法A优于方法B"

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -1,7 +1,9 @@
 import json
 from types import SimpleNamespace
+from pathlib import Path
 
 from agent.memory.extraction import extract_memory_candidates
+from utils.utils import ensure_local_user, init_database, save_api_key, save_base_url, save_model_name
 
 
 def test_extract_memory_candidates_uses_llm_output_without_keyword_rules(monkeypatch) -> None:
@@ -35,9 +37,9 @@ def test_extract_memory_candidates_uses_llm_output_without_keyword_rules(monkeyp
                 )
             )
 
-    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
-    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
-    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid, db_name="./database.sqlite": f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid, db_name="./database.sqlite": "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid, db_name="./database.sqlite": "https://example.test")
     monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
 
     candidates = extract_memory_candidates(
@@ -58,6 +60,8 @@ def test_extract_memory_candidates_uses_llm_output_without_keyword_rules(monkeyp
     assert candidates[0]["evidence"][0]["episode_uid"] == "ep-2"
     assert "长期保存" in str(captured["messages"])
     assert "旧结论" in str(captured["messages"])
+    assert "fragment statement" in str(captured["messages"]).lower()
+    assert "q/a" in str(captured["messages"]).lower()
 
 
 def test_extract_memory_candidates_returns_empty_when_llm_returns_no_candidates(monkeypatch) -> None:
@@ -65,9 +69,9 @@ def test_extract_memory_candidates_returns_empty_when_llm_returns_no_candidates(
         def invoke(self, _messages):
             return SimpleNamespace(content=json.dumps({"candidates": []}, ensure_ascii=False))
 
-    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
-    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
-    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid, db_name="./database.sqlite": f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid, db_name="./database.sqlite": "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid, db_name="./database.sqlite": "https://example.test")
     monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
 
     candidates = extract_memory_candidates(
@@ -82,3 +86,142 @@ def test_extract_memory_candidates_returns_empty_when_llm_returns_no_candidates(
     )
 
     assert candidates == []
+
+
+def test_extract_memory_candidates_reads_credentials_from_provided_db(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "memory-extraction.sqlite"
+    init_database(str(db_path))
+    ensure_local_user("local-user", db_name=str(db_path))
+    save_api_key("local-user", "test-key", db_name=str(db_path))
+    save_model_name("local-user", "fake-model", db_name=str(db_path))
+    save_base_url("local-user", "https://example.test", db_name=str(db_path))
+
+    class _FakeModel:
+        def invoke(self, _messages):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "candidates": [
+                            {
+                                "action": "ADD",
+                                "memory_type": "user_memory",
+                                "title": "回答偏好",
+                                "content": "以后用中文要点回答",
+                                "canonical_text": "以后用中文要点回答",
+                                "dedup_key": "user:response_preferences",
+                                "confidence": 0.91,
+                                "evidence": [{"quote": "以后用中文要点回答"}],
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
+
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-db",
+            "prompt": "之后回复改成中文要点。",
+            "answer": "收到，之后会用中文要点回答。",
+        },
+        recent_episodes=[],
+        active_memories=[],
+        user_uuid="local-user",
+        db_name=str(db_path),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["memory_type"] == "user_memory"
+    assert candidates[0]["source_episode_uid"] == "ep-db"
+
+
+def test_extract_memory_candidates_accepts_single_candidate_json_object(monkeypatch) -> None:
+    class _FakeModel:
+        def invoke(self, _messages):
+            return SimpleNamespace(
+                content="""
+这里是提取结果：
+{
+  "action": "ADD",
+  "memory_type": "knowledge_memory",
+  "title": "项目事实",
+  "content": "project Apollo deadline moved to Apr 30",
+  "canonical_text": "project Apollo deadline moved to Apr 30",
+  "dedup_key": "project:apollo_deadline",
+  "confidence": 0.88,
+  "evidence": [{"quote": "project Apollo deadline moved to Apr 30"}]
+}
+"""
+            )
+
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid, db_name="./database.sqlite": f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid, db_name="./database.sqlite": "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid, db_name="./database.sqlite": "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
+
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-single",
+            "prompt": "记录一下 Apollo 项目时间变更。",
+            "answer": "project Apollo deadline moved to Apr 30",
+        },
+        recent_episodes=[],
+        active_memories=[],
+        user_uuid="local-user",
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["memory_type"] == "knowledge_memory"
+    assert candidates[0]["canonical_text"] == "project Apollo deadline moved to Apr 30"
+
+
+def test_extract_memory_candidates_accepts_string_evidence_items(monkeypatch) -> None:
+    class _FakeModel:
+        def invoke(self, _messages):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "candidates": [
+                            {
+                                "action": "ADD",
+                                "memory_type": "user_memory",
+                                "title": "Response preference",
+                                "content": "user prefers concise answers",
+                                "canonical_text": "user prefers concise answers",
+                                "dedup_key": "user:concise_answers",
+                                "confidence": 0.93,
+                                "evidence": [
+                                    "Please keep future replies concise.",
+                                    "Understood, I will keep future replies concise.",
+                                ],
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid, db_name="./database.sqlite": f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid, db_name="./database.sqlite": "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid, db_name="./database.sqlite": "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
+
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-evidence",
+            "prompt": "Please keep future replies concise.",
+            "answer": "Understood, I will keep future replies concise.",
+        },
+        recent_episodes=[],
+        active_memories=[],
+        user_uuid="local-user",
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["evidence"][0]["episode_uid"] == "ep-evidence"
+    assert candidates[0]["evidence"][0]["quote"] == "Please keep future replies concise."

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -1,36 +1,84 @@
+import json
+from types import SimpleNamespace
+
 from agent.memory.extraction import extract_memory_candidates
 
 
-def test_extract_memory_candidates_user_memory() -> None:
-    candidates = extract_memory_candidates(
-        episode={
-            "episode_uid": "ep-1",
-            "prompt": "请记住，以后默认用中文项目符号回答",
-            "answer": "收到，后续默认使用中文项目符号回答。",
-        },
-        recent_episodes=[],
-    )
+def test_extract_memory_candidates_uses_llm_output_without_keyword_rules(monkeypatch) -> None:
+    captured = {}
 
-    assert len(candidates) == 1
-    assert candidates[0]["memory_type"] == "user_memory"
-    assert candidates[0]["action"] == "ADD"
-    assert candidates[0]["source_episode_uid"] == "ep-1"
-    assert candidates[0]["evidence"][0]["episode_uid"] == "ep-1"
-    assert "默认" in candidates[0]["canonical_text"]
+    class _FakeModel:
+        def invoke(self, messages):
+            captured["messages"] = messages
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "candidates": [
+                            {
+                                "action": "ADD",
+                                "memory_type": "knowledge_memory",
+                                "title": "实验结论",
+                                "content": "方法A在该任务上优于方法B",
+                                "canonical_text": "方法A优于方法B",
+                                "dedup_key": "knowledge:paper-main-finding",
+                                "confidence": 0.82,
+                                "evidence": [
+                                    {
+                                        "episode_uid": "ep-2",
+                                        "quote": "方法A在该任务上优于方法B",
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                )
+            )
 
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
 
-def test_extract_memory_candidates_knowledge_memory() -> None:
     candidates = extract_memory_candidates(
         episode={
             "episode_uid": "ep-2",
-            "prompt": "这篇论文的主要结论是什么？",
-            "answer": "主要结论是方法A在CIFAR-10上优于方法B。",
+            "prompt": "帮我沉淀这轮对话里真正值得长期保存的内容",
+            "answer": "可以长期保留的事实是方法A在该任务上优于方法B。",
         },
-        recent_episodes=[],
+        recent_episodes=[{"episode_uid": "ep-1", "prompt": "上一轮", "answer": "上一轮回答"}],
+        active_memories=[{"memory_uid": "m-1", "memory_type": "knowledge_memory", "canonical_text": "旧结论"}],
+        user_uuid="local-user",
     )
 
     assert len(candidates) == 1
     assert candidates[0]["memory_type"] == "knowledge_memory"
     assert candidates[0]["action"] == "ADD"
     assert candidates[0]["source_episode_uid"] == "ep-2"
-    assert candidates[0]["evidence"][0]["quote"] == "主要结论是方法A在CIFAR-10上优于方法B。"
+    assert candidates[0]["evidence"][0]["episode_uid"] == "ep-2"
+    assert "长期保存" in str(captured["messages"])
+    assert "旧结论" in str(captured["messages"])
+
+
+def test_extract_memory_candidates_returns_empty_when_llm_returns_no_candidates(monkeypatch) -> None:
+    class _FakeModel:
+        def invoke(self, _messages):
+            return SimpleNamespace(content=json.dumps({"candidates": []}, ensure_ascii=False))
+
+    monkeypatch.setattr("agent.memory.extraction.read_api_key_for_user", lambda uuid: f"k:{uuid}")
+    monkeypatch.setattr("agent.memory.extraction.read_model_name_for_user", lambda uuid: "fake-model")
+    monkeypatch.setattr("agent.memory.extraction.read_base_url_for_user", lambda uuid: "https://example.test")
+    monkeypatch.setattr("agent.memory.extraction.create_chat_model", lambda **_kwargs: _FakeModel())
+
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-3",
+            "prompt": "这一轮只是在寒暄",
+            "answer": "好的，继续。",
+        },
+        recent_episodes=[],
+        active_memories=[],
+        user_uuid="local-user",
+    )
+
+    assert candidates == []

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -1,0 +1,36 @@
+from agent.memory.extraction import extract_memory_candidates
+
+
+def test_extract_memory_candidates_user_memory() -> None:
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-1",
+            "prompt": "请记住，以后默认用中文项目符号回答",
+            "answer": "收到，后续默认使用中文项目符号回答。",
+        },
+        recent_episodes=[],
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["memory_type"] == "user_memory"
+    assert candidates[0]["action"] == "ADD"
+    assert candidates[0]["source_episode_uid"] == "ep-1"
+    assert candidates[0]["evidence"][0]["episode_uid"] == "ep-1"
+    assert "默认" in candidates[0]["canonical_text"]
+
+
+def test_extract_memory_candidates_knowledge_memory() -> None:
+    candidates = extract_memory_candidates(
+        episode={
+            "episode_uid": "ep-2",
+            "prompt": "这篇论文的主要结论是什么？",
+            "answer": "主要结论是方法A在CIFAR-10上优于方法B。",
+        },
+        recent_episodes=[],
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0]["memory_type"] == "knowledge_memory"
+    assert candidates[0]["action"] == "ADD"
+    assert candidates[0]["source_episode_uid"] == "ep-2"
+    assert candidates[0]["evidence"][0]["quote"] == "主要结论是方法A在CIFAR-10上优于方法B。"

--- a/tests/unit/test_memory_leader_write.py
+++ b/tests/unit/test_memory_leader_write.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from agent.memory.service import write_memory_from_leader
+from agent.memory.store import list_project_memory_items
+from utils.utils import ensure_local_user, init_database
+
+
+def test_write_memory_from_leader_deduplicates_active_memory(tmp_path: Path) -> None:
+    db_path = tmp_path / "leader-memory.sqlite"
+    init_database(str(db_path))
+    ensure_local_user("local-user", db_name=str(db_path))
+
+    first = write_memory_from_leader(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        items=[
+            {
+                "memory_type": "user_memory",
+                "content": "user prefers concise answers",
+                "canonical_text": "user prefers concise answers",
+            }
+        ],
+        db_name=str(db_path),
+    )
+    second = write_memory_from_leader(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        items=[
+            {
+                "memory_type": "user_memory",
+                "content": "user prefers concise answers",
+                "canonical_text": "user prefers concise answers",
+            }
+        ],
+        db_name=str(db_path),
+    )
+
+    active_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid="project-1",
+        status="active",
+        limit=10,
+        db_name=str(db_path),
+    )
+
+    assert first[0]["action"] == "ADD"
+    assert second[0]["action"] == "NONE"
+    assert len(active_items) == 1
+    assert active_items[0]["canonical_text"] == "user prefers concise answers"

--- a/tests/unit/test_memory_legacy_facades.py
+++ b/tests/unit/test_memory_legacy_facades.py
@@ -1,0 +1,8 @@
+import utils.utils as legacy_utils
+
+
+def test_legacy_memory_facades_are_not_exposed() -> None:
+    assert not hasattr(legacy_utils, "upsert_project_memory_item")
+    assert not hasattr(legacy_utils, "list_project_memory_items")
+    assert not hasattr(legacy_utils, "search_project_memory_items")
+    assert not hasattr(legacy_utils, "touch_memory_items")

--- a/tests/unit/test_memory_reconcile.py
+++ b/tests/unit/test_memory_reconcile.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+
+from agent.memory.reconcile import apply_memory_candidates
+from agent.memory.store import list_project_memory_items, upsert_project_memory_item
+from utils.utils import ensure_local_user, init_database
+
+
+def _prepare_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "database.sqlite"
+    init_database(str(db_path))
+    ensure_local_user("local-user", db_name=str(db_path))
+    return db_path
+
+
+def test_apply_memory_candidates_updates_existing_active_item(tmp_path: Path) -> None:
+    db_path = _prepare_db(tmp_path)
+    upsert_project_memory_item(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        memory_type="knowledge_memory",
+        title="结论",
+        content="旧结论",
+        canonical_text="旧结论",
+        dedup_key="knowledge:conclusion",
+        status="active",
+        db_name=str(db_path),
+    )
+
+    results = apply_memory_candidates(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        candidates=[
+            {
+                "action": "UPDATE",
+                "memory_type": "knowledge_memory",
+                "title": "结论",
+                "content": "新结论",
+                "canonical_text": "新结论",
+                "dedup_key": "knowledge:conclusion",
+                "confidence": 0.8,
+                "source_episode_uid": "ep-1",
+                "evidence": [{"episode_uid": "ep-1", "quote": "新结论"}],
+            }
+        ],
+        db_name=str(db_path),
+    )
+
+    items = list_project_memory_items(
+        uuid="local-user",
+        project_uid="project-1",
+        status="active",
+        limit=10,
+        db_name=str(db_path),
+    )
+    assert results[0]["action"] == "UPDATE"
+    assert len(items) == 1
+    assert items[0]["canonical_text"] == "新结论"
+
+
+def test_apply_memory_candidates_deletes_existing_active_item(tmp_path: Path) -> None:
+    db_path = _prepare_db(tmp_path)
+    upsert_project_memory_item(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        memory_type="user_memory",
+        title="语言偏好",
+        content="默认用中文回答",
+        canonical_text="默认用中文回答",
+        dedup_key="user:response_preferences",
+        status="active",
+        db_name=str(db_path),
+    )
+
+    results = apply_memory_candidates(
+        uuid="local-user",
+        project_uid="project-1",
+        session_uid="session-1",
+        candidates=[
+            {
+                "action": "DELETE",
+                "memory_type": "user_memory",
+                "title": "语言偏好",
+                "content": "",
+                "canonical_text": "默认用中文回答",
+                "dedup_key": "user:response_preferences",
+                "confidence": 0.9,
+                "source_episode_uid": "ep-2",
+                "evidence": [{"episode_uid": "ep-2", "quote": "删除该偏好"}],
+            }
+        ],
+        db_name=str(db_path),
+    )
+
+    active_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid="project-1",
+        status="active",
+        limit=10,
+        db_name=str(db_path),
+    )
+    deleted_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid="project-1",
+        status="deleted",
+        limit=10,
+        db_name=str(db_path),
+    )
+    assert results[0]["action"] == "DELETE"
+    assert active_items == []
+    assert len(deleted_items) == 1

--- a/tests/unit/test_memory_worker.py
+++ b/tests/unit/test_memory_worker.py
@@ -13,7 +13,28 @@ def _prepare_db(tmp_path: Path) -> Path:
     return db_path
 
 
-def test_task_memory_writer_reads_episode_and_bounded_context(tmp_path: Path) -> None:
+def _fake_candidates(*, episode, recent_episodes, active_memories, user_uuid):
+    del recent_episodes, active_memories, user_uuid
+    prompt = str(episode["prompt"])
+    answer = str(episode["answer"])
+    canonical = answer.replace("收到，后续默认用", "").replace("回答。", "").strip("。")
+    return [
+        {
+            "action": "ADD",
+            "memory_type": "user_memory",
+            "title": prompt,
+            "content": f"{prompt}\n{answer}",
+            "canonical_text": canonical or answer,
+            "dedup_key": "user:response_preferences",
+            "confidence": 0.9,
+            "source_episode_uid": str(episode["episode_uid"]),
+            "evidence": [{"episode_uid": str(episode["episode_uid"]), "quote": prompt}],
+        }
+    ]
+
+
+def test_task_memory_writer_reads_episode_and_bounded_context(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("utils.tasks.extract_memory_candidates", _fake_candidates)
     db_path = _prepare_db(tmp_path)
     project_uid = "project-1"
     session_uid = ensure_default_project_session(
@@ -53,7 +74,8 @@ def test_task_memory_writer_reads_episode_and_bounded_context(tmp_path: Path) ->
     assert isinstance(payload["candidates"], list)
 
 
-def test_task_memory_writer_is_idempotent_for_same_episode(tmp_path: Path) -> None:
+def test_task_memory_writer_is_idempotent_for_same_episode(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("utils.tasks.extract_memory_candidates", _fake_candidates)
     db_path = _prepare_db(tmp_path)
     project_uid = "project-1"
     session_uid = ensure_default_project_session(
@@ -86,7 +108,8 @@ def test_task_memory_writer_is_idempotent_for_same_episode(tmp_path: Path) -> No
     assert active_items[0]["memory_type"] == "user_memory"
 
 
-def test_task_memory_writer_supersedes_old_user_memory(tmp_path: Path) -> None:
+def test_task_memory_writer_supersedes_old_user_memory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("utils.tasks.extract_memory_candidates", _fake_candidates)
     db_path = _prepare_db(tmp_path)
     project_uid = "project-1"
     session_uid = ensure_default_project_session(

--- a/tests/unit/test_memory_worker.py
+++ b/tests/unit/test_memory_worker.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from agent.adapters.sqlite.project_repository import ensure_default_project_session
-from agent.memory.store import save_project_memory_episode
+from agent.memory.store import list_project_memory_items, save_project_memory_episode
 from utils.tasks import task_memory_writer
 from utils.utils import ensure_local_user, init_database
 
@@ -50,3 +50,86 @@ def test_task_memory_writer_reads_episode_and_bounded_context(tmp_path: Path) ->
     assert payload["episode"]["episode_uid"] == current_uid
     assert payload["episode"]["prompt"] == "第二个问题"
     assert [item["episode_uid"] for item in payload["recent_episodes"]] == [current_uid, earlier_uid]
+    assert isinstance(payload["candidates"], list)
+
+
+def test_task_memory_writer_is_idempotent_for_same_episode(tmp_path: Path) -> None:
+    db_path = _prepare_db(tmp_path)
+    project_uid = "project-1"
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+    episode_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住，以后默认用中文回答",
+        answer="收到，后续默认用中文回答。",
+        db_name=str(db_path),
+    )
+
+    ok_first, _ = task_memory_writer("task-1", episode_uid, "local-user", db_name=str(db_path))
+    ok_second, _ = task_memory_writer("task-2", episode_uid, "local-user", db_name=str(db_path))
+
+    assert ok_first is True
+    assert ok_second is True
+    active_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid=project_uid,
+        status="active",
+        limit=10,
+        db_name=str(db_path),
+    )
+    assert len(active_items) == 1
+    assert active_items[0]["memory_type"] == "user_memory"
+
+
+def test_task_memory_writer_supersedes_old_user_memory(tmp_path: Path) -> None:
+    db_path = _prepare_db(tmp_path)
+    project_uid = "project-1"
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+    first_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住，以后默认用中文回答",
+        answer="收到，后续默认用中文回答。",
+        db_name=str(db_path),
+    )
+    second_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住，以后默认用英文回答",
+        answer="收到，后续默认用英文回答。",
+        db_name=str(db_path),
+    )
+
+    assert task_memory_writer("task-1", first_uid, "local-user", db_name=str(db_path))[0] is True
+    assert task_memory_writer("task-2", second_uid, "local-user", db_name=str(db_path))[0] is True
+
+    active_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid=project_uid,
+        status="active",
+        limit=10,
+        db_name=str(db_path),
+    )
+    superseded_items = list_project_memory_items(
+        uuid="local-user",
+        project_uid=project_uid,
+        status="superseded",
+        limit=10,
+        db_name=str(db_path),
+    )
+
+    assert len(active_items) == 1
+    assert "英文" in active_items[0]["canonical_text"]
+    assert len(superseded_items) == 1
+    assert "中文" in superseded_items[0]["canonical_text"]

--- a/tests/unit/test_memory_worker.py
+++ b/tests/unit/test_memory_worker.py
@@ -13,8 +13,8 @@ def _prepare_db(tmp_path: Path) -> Path:
     return db_path
 
 
-def _fake_candidates(*, episode, recent_episodes, active_memories, user_uuid):
-    del recent_episodes, active_memories, user_uuid
+def _fake_candidates(*, episode, recent_episodes, active_memories, user_uuid, db_name):
+    del recent_episodes, active_memories, user_uuid, db_name
     prompt = str(episode["prompt"])
     answer = str(episode["answer"])
     canonical = answer.replace("收到，后续默认用", "").replace("回答。", "").strip("。")

--- a/tests/unit/test_memory_worker.py
+++ b/tests/unit/test_memory_worker.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from agent.adapters.sqlite.project_repository import ensure_default_project_session
+from agent.memory.store import save_project_memory_episode
+from utils.tasks import task_memory_writer
+from utils.utils import ensure_local_user, init_database
+
+
+def _prepare_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "database.sqlite"
+    init_database(str(db_path))
+    ensure_local_user("local-user", db_name=str(db_path))
+    return db_path
+
+
+def test_task_memory_writer_reads_episode_and_bounded_context(tmp_path: Path) -> None:
+    db_path = _prepare_db(tmp_path)
+    project_uid = "project-1"
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+    earlier_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="第一个问题",
+        answer="第一个回答",
+        db_name=str(db_path),
+    )
+    current_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="第二个问题",
+        answer="第二个回答",
+        db_name=str(db_path),
+    )
+
+    ok, payload = task_memory_writer(
+        "task-1",
+        current_uid,
+        "local-user",
+        db_name=str(db_path),
+        context_limit=2,
+    )
+
+    assert ok is True
+    assert payload["episode"]["episode_uid"] == current_uid
+    assert payload["episode"]["prompt"] == "第二个问题"
+    assert [item["episode_uid"] for item in payload["recent_episodes"]] == [current_uid, earlier_uid]

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -13,10 +13,16 @@ def test_build_system_prompt_does_not_raise():
     assert "测试文档" in result
     assert "测试项目" in result
     assert "<mindmap>{" in result
+    assert "query_memory" in result
+    assert "先调用 query_memory" in result
 
 
 def test_create_paper_agent_session_uses_runtime_agent_builder(monkeypatch):
     captured = {}
+
+    def fake_build_runtime_tools(**kwargs):
+        captured["runtime_tool_kwargs"] = kwargs
+        return ["tool-a", "tool-b"]
 
     def fake_create_runtime_agent(*, model, tools, system_prompt, **kwargs):
         captured["model"] = model
@@ -27,7 +33,7 @@ def test_create_paper_agent_session_uses_runtime_agent_builder(monkeypatch):
     monkeypatch.setattr(
         paper_agent_module,
         "build_runtime_tools",
-        lambda **_kwargs: ["tool-a", "tool-b"],
+        fake_build_runtime_tools,
     )
     monkeypatch.setattr(
         paper_agent_module,
@@ -45,6 +51,38 @@ def test_create_paper_agent_session_uses_runtime_agent_builder(monkeypatch):
     assert captured["model"] == "fake-llm"
     assert captured["tools"] == ["tool-a", "tool-b"]
     assert "未知文档" in captured["system_prompt"]
+    assert captured["runtime_tool_kwargs"]["write_memory_fn"] is None
+    assert captured["runtime_tool_kwargs"]["query_memory_fn"] is None
+
+
+def test_create_paper_agent_session_injects_write_memory_tool_when_scope_available(monkeypatch):
+    captured = {}
+
+    def fake_build_runtime_tools(**kwargs):
+        captured["runtime_tool_kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr(
+        paper_agent_module,
+        "build_runtime_tools",
+        fake_build_runtime_tools,
+    )
+    monkeypatch.setattr(
+        paper_agent_module,
+        "create_runtime_agent",
+        lambda **_kwargs: {"name": "fake-agent"},
+    )
+
+    paper_agent_module.create_paper_agent_session(
+        llm="fake-llm",
+        search_document_fn=lambda q: q,
+        user_uuid="u1",
+        project_uid="p1",
+        session_uid="s1",
+    )
+
+    assert callable(captured["runtime_tool_kwargs"]["write_memory_fn"])
+    assert callable(captured["runtime_tool_kwargs"]["query_memory_fn"])
 
 
 def test_paper_agent_session_runtime_config_contains_thread_id():

--- a/tests/unit/test_project_session_history.py
+++ b/tests/unit/test_project_session_history.py
@@ -15,6 +15,7 @@ from agent.memory.store import (
     get_project_session_compact_memory,
     get_project_memory_episode,
     list_project_memory_items,
+    query_long_term_memory,
     save_project_memory_episode,
     save_project_session_compact_memory,
     search_project_memory_items,
@@ -387,3 +388,83 @@ def test_project_memory_item_structured_fields_roundtrip(tmp_path: Path) -> None
     assert items[0]["confidence"] == 0.92
     assert items[0]["source_episode_uid"] == episode_uid
     assert items[0]["evidence"] == [{"episode_uid": episode_uid, "quote": "以后都用项目符号回答"}]
+
+
+def test_query_long_term_memory_filters_active_typed_memories(tmp_path: Path) -> None:
+    db_path, project_uid = _prepare_project(tmp_path)
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+    episode_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住以后默认用中文回答",
+        answer="收到，后续默认用中文回答。",
+        db_name=str(db_path),
+    )
+    upsert_project_memory_item(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        memory_type="user_memory",
+        title="语言偏好",
+        content="默认用中文回答",
+        canonical_text="默认用中文回答",
+        dedup_key="user:response_preferences",
+        status="active",
+        source_episode_uid=episode_uid,
+        db_name=str(db_path),
+    )
+    upsert_project_memory_item(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        memory_type="knowledge_memory",
+        title="旧结论",
+        content="方法A不如方法B",
+        canonical_text="方法A不如方法B",
+        dedup_key="knowledge:main-conclusion-old",
+        status="superseded",
+        source_episode_uid=episode_uid,
+        db_name=str(db_path),
+    )
+    upsert_project_memory_item(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        memory_type="knowledge_memory",
+        title="新结论",
+        content="方法A优于方法B",
+        canonical_text="方法A优于方法B",
+        dedup_key="knowledge:main-conclusion",
+        status="active",
+        source_episode_uid=episode_uid,
+        db_name=str(db_path),
+    )
+
+    knowledge = query_long_term_memory(
+        uuid="local-user",
+        project_uid=project_uid,
+        query="主要结论",
+        memory_type="knowledge_memory",
+        status="active",
+        limit=5,
+        db_name=str(db_path),
+    )
+    user_items = query_long_term_memory(
+        uuid="local-user",
+        project_uid=project_uid,
+        query="",
+        memory_type="user_memory",
+        status="active",
+        limit=5,
+        db_name=str(db_path),
+    )
+
+    assert len(knowledge) == 1
+    assert knowledge[0]["canonical_text"] == "方法A优于方法B"
+    assert len(user_items) == 1
+    assert user_items[0]["memory_type"] == "user_memory"

--- a/tests/unit/test_project_session_history.py
+++ b/tests/unit/test_project_session_history.py
@@ -13,7 +13,9 @@ from agent.adapters.sqlite.project_repository import (
 )
 from agent.memory.store import (
     get_project_session_compact_memory,
+    get_project_memory_episode,
     list_project_memory_items,
+    save_project_memory_episode,
     save_project_session_compact_memory,
     search_project_memory_items,
     upsert_project_memory_item,
@@ -267,6 +269,36 @@ def test_project_memory_item_upsert_and_search(tmp_path: Path) -> None:
     assert "方法A优于方法B" in matched[0]["content"]
 
 
+def test_project_memory_episode_roundtrip(tmp_path: Path) -> None:
+    db_path, project_uid = _prepare_project(tmp_path)
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+
+    episode_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="请记住以后默认输出中文摘要",
+        answer="好的，后续我会默认输出中文摘要。",
+        db_name=str(db_path),
+    )
+    assert episode_uid
+
+    episode = get_project_memory_episode(
+        episode_uid=episode_uid,
+        db_name=str(db_path),
+    )
+    assert episode["episode_uid"] == episode_uid
+    assert episode["uuid"] == "local-user"
+    assert episode["project_uid"] == project_uid
+    assert episode["session_uid"] == session_uid
+    assert episode["prompt"] == "请记住以后默认输出中文摘要"
+    assert episode["answer"] == "好的，后续我会默认输出中文摘要。"
+
+
 def test_project_memory_expired_items_are_filtered(tmp_path: Path) -> None:
     db_path, project_uid = _prepare_project(tmp_path)
     session_uid = ensure_default_project_session(
@@ -307,3 +339,51 @@ def test_project_memory_expired_items_are_filtered(tmp_path: Path) -> None:
     )
     assert len(items) == 1
     assert items[0]["title"] == "有效记忆"
+
+
+def test_project_memory_item_structured_fields_roundtrip(tmp_path: Path) -> None:
+    db_path, project_uid = _prepare_project(tmp_path)
+    session_uid = ensure_default_project_session(
+        project_uid=project_uid,
+        uuid="local-user",
+        db_name=str(db_path),
+    )
+    episode_uid = save_project_memory_episode(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        prompt="用户说以后都用项目符号回答",
+        answer="收到，后续默认使用项目符号回答。",
+        db_name=str(db_path),
+    )
+
+    memory_uid = upsert_project_memory_item(
+        uuid="local-user",
+        project_uid=project_uid,
+        session_uid=session_uid,
+        memory_type="procedural",
+        title="回答偏好",
+        content="以后默认使用项目符号回答",
+        canonical_text="默认使用项目符号回答",
+        dedup_key="pref:bullet-style",
+        status="active",
+        confidence=0.92,
+        source_episode_uid=episode_uid,
+        evidence=[{"episode_uid": episode_uid, "quote": "以后都用项目符号回答"}],
+        db_name=str(db_path),
+    )
+    assert memory_uid
+
+    items = list_project_memory_items(
+        uuid="local-user",
+        project_uid=project_uid,
+        limit=10,
+        db_name=str(db_path),
+    )
+    assert len(items) == 1
+    assert items[0]["canonical_text"] == "默认使用项目符号回答"
+    assert items[0]["dedup_key"] == "pref:bullet-style"
+    assert items[0]["status"] == "active"
+    assert items[0]["confidence"] == 0.92
+    assert items[0]["source_episode_uid"] == episode_uid
+    assert items[0]["evidence"] == [{"episode_uid": episode_uid, "quote": "以后都用项目符号回答"}]

--- a/tests/unit/test_tool_builder_memory.py
+++ b/tests/unit/test_tool_builder_memory.py
@@ -1,0 +1,88 @@
+import json
+
+from agent.tools.builder import build_agent_tools
+from agent.tools.memory import build_query_memory_tool, build_write_memory_tool
+
+
+def test_build_agent_tools_includes_write_memory_tool_when_available() -> None:
+    tools = build_agent_tools(
+        search_document_fn=lambda _q: "doc",
+        write_memory_fn=lambda _items: [{"action": "ADD"}],
+    )
+
+    names = [str(getattr(item, "name", "") or "") for item in tools]
+    assert "write_memory" in names
+
+
+def test_build_agent_tools_includes_query_memory_tool_when_available() -> None:
+    tools = build_agent_tools(
+        search_document_fn=lambda _q: "doc",
+        query_memory_fn=lambda _query, _memory_type=None, _limit=5: [],
+    )
+
+    names = [str(getattr(item, "name", "") or "") for item in tools]
+    assert "query_memory" in names
+
+
+def test_query_memory_tool_normalizes_args_and_returns_json() -> None:
+    captured: dict[str, object] = {}
+
+    def _query_memory(query: str, memory_type: str | None, limit: int) -> list[dict[str, object]]:
+        captured["query"] = query
+        captured["memory_type"] = memory_type
+        captured["limit"] = limit
+        return [{"canonical_text": "user prefers concise answers"}]
+
+    tool = build_query_memory_tool(_query_memory)
+    result = tool.invoke({"query": "  concise replies  ", "memory_type": "", "limit": 0})
+
+    assert captured == {
+        "query": "concise replies",
+        "memory_type": None,
+        "limit": 1,
+    }
+    assert json.loads(result) == {
+        "results": [{"canonical_text": "user prefers concise answers"}]
+    }
+
+
+def test_write_memory_tool_serializes_items_and_returns_json() -> None:
+    captured: dict[str, object] = {}
+
+    def _write_memory(items: list[dict[str, object]]) -> list[dict[str, object]]:
+        captured["items"] = items
+        return [{"action": "ADD", "canonical_text": items[0]["canonical_text"]}]
+
+    tool = build_write_memory_tool(_write_memory)
+    result = tool.invoke(
+        {
+            "items": [
+                {
+                    "memory_type": "user_memory",
+                    "content": "user prefers concise answers",
+                    "canonical_text": "user prefers concise answers",
+                    "title": "Answer preference",
+                }
+            ]
+        }
+    )
+
+    assert captured["items"] == [
+        {
+            "memory_type": "user_memory",
+            "content": "user prefers concise answers",
+            "canonical_text": "user prefers concise answers",
+            "title": "Answer preference",
+            "dedup_key": "",
+            "action": "ADD",
+            "confidence": 0.9,
+        }
+    ]
+    assert json.loads(result) == {
+        "results": [
+            {
+                "action": "ADD",
+                "canonical_text": "user prefers concise answers",
+            }
+        ]
+    }

--- a/tests/unit/test_ui_agent_center_helpers.py
+++ b/tests/unit/test_ui_agent_center_helpers.py
@@ -77,17 +77,40 @@ def test_build_routing_context_keeps_stable_prefix_under_limit(monkeypatch):
 
 def test_persist_turn_memory(monkeypatch):
     captured = {}
+    queued = {}
     monkeypatch.setattr(
-        "agent.application.agent_center.memory.classify_turn_memory_type",
-        lambda _q, _a: "semantic",
+        "agent.application.agent_center.memory.save_project_memory_episode",
+        lambda **kwargs: captured.update(kwargs) or "episode-1",
     )
     monkeypatch.setattr(
-        "agent.application.agent_center.memory.ttl_for_memory_type",
-        lambda _t: "2099-01-01T00:00:00",
+        "agent.application.agent_center.memory.create_task",
+        lambda task_id, uid, content_type, db_name="./database.sqlite": queued.update(
+            {"task_id": task_id, "uid": uid, "content_type": content_type, "db_name": db_name}
+        ),
     )
     monkeypatch.setattr(
-        "agent.application.agent_center.memory.upsert_project_memory_item",
-        lambda **kwargs: captured.update(kwargs),
+        "agent.application.agent_center.memory.enqueue_task",
+        lambda task_func, task_id, episode_uid, user_uuid, db_name="./database.sqlite": queued.update(
+            {
+                "task_func": getattr(task_func, "__name__", ""),
+                "enqueue_task_id": task_id,
+                "episode_uid": episode_uid,
+                "user_uuid": user_uuid,
+                "enqueue_db_name": db_name,
+            }
+        )
+        or {"mode": "queued", "job_id": "job-1"},
+    )
+    monkeypatch.setattr(
+        "agent.application.agent_center.memory.update_task_status",
+        lambda task_id, status, job_id=None, db_name="./database.sqlite": queued.update(
+            {
+                "status_task_id": task_id,
+                "status": getattr(status, "value", status),
+                "job_id": job_id,
+                "status_db_name": db_name,
+            }
+        ),
     )
     persist_turn_memory(
         user_uuid="u1",
@@ -99,3 +122,12 @@ def test_persist_turn_memory(monkeypatch):
     assert captured["uuid"] == "u1"
     assert captured["project_uid"] == "p1"
     assert captured["session_uid"] == "s1"
+    assert captured["prompt"] == "question"
+    assert captured["answer"] == "answer"
+    assert queued["uid"] == "episode-1"
+    assert queued["content_type"] == "memory_writer"
+    assert queued["task_func"] == "task_memory_writer"
+    assert queued["episode_uid"] == "episode-1"
+    assert queued["user_uuid"] == "u1"
+    assert queued["status"] == "queued"
+    assert queued["job_id"] == "job-1"

--- a/ui/agent_center_page.py
+++ b/ui/agent_center_page.py
@@ -132,7 +132,7 @@ def run_agent_center_page() -> None:
     )
     from agent.memory.store import (
         get_project_session_compact_memory,
-        search_project_memory_items,
+        query_long_term_memory,
     )
     from agent.metrics import record_query_metrics
     from agent.mindmap_renderer import render_mindmap_html_with_cli
@@ -576,7 +576,7 @@ def run_agent_center_page() -> None:
                 **kwargs,
                 detect_language_fn=detect_language,
                 with_language_hint_fn=with_language_hint,
-                search_project_memory_items_fn=search_project_memory_items,
+                search_project_memory_items_fn=query_long_term_memory,
                 inject_long_term_memory_fn=inject_long_term_memory,
                 memory_limit=4,
             ),

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -55,9 +55,17 @@ except ImportError:
     from agent.memory.reconcile import apply_memory_candidates
 
 try:
-    from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
+    from agent.memory.store import (
+        get_project_memory_episode,
+        list_project_memory_episodes,
+        list_project_memory_items,
+    )
 except ImportError:
-    from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
+    from agent.memory.store import (
+        get_project_memory_episode,
+        list_project_memory_episodes,
+        list_project_memory_items,
+    )
 
 try:
     from agent.llm_provider import build_openai_compatible_chat_model
@@ -416,9 +424,18 @@ def task_memory_writer(
             limit=max(1, int(context_limit)),
             db_name=db_name,
         )
+        active_memories = list_project_memory_items(
+            uuid=user_uuid,
+            project_uid=str(episode.get("project_uid") or ""),
+            status="active",
+            limit=20,
+            db_name=db_name,
+        )
         candidates = extract_memory_candidates(
             episode=episode,
             recent_episodes=recent_episodes,
+            active_memories=active_memories,
+            user_uuid=user_uuid,
         )
         reconcile_results = apply_memory_candidates(
             uuid=user_uuid,
@@ -430,6 +447,7 @@ def task_memory_writer(
         payload = {
             "episode": episode,
             "recent_episodes": recent_episodes,
+            "active_memories": active_memories,
             "candidates": candidates,
             "reconcile_results": reconcile_results,
         }

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -45,6 +45,16 @@ from langchain_core.prompts import ChatPromptTemplate
 from openai import OpenAI
 
 try:
+    from agent.memory.extraction import extract_memory_candidates
+except ImportError:
+    from agent.memory.extraction import extract_memory_candidates
+
+try:
+    from agent.memory.reconcile import apply_memory_candidates
+except ImportError:
+    from agent.memory.reconcile import apply_memory_candidates
+
+try:
     from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
 except ImportError:
     from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
@@ -406,9 +416,22 @@ def task_memory_writer(
             limit=max(1, int(context_limit)),
             db_name=db_name,
         )
+        candidates = extract_memory_candidates(
+            episode=episode,
+            recent_episodes=recent_episodes,
+        )
+        reconcile_results = apply_memory_candidates(
+            uuid=user_uuid,
+            project_uid=str(episode.get("project_uid") or ""),
+            session_uid=str(episode.get("session_uid") or ""),
+            candidates=candidates,
+            db_name=db_name,
+        )
         payload = {
             "episode": episode,
             "recent_episodes": recent_episodes,
+            "candidates": candidates,
+            "reconcile_results": reconcile_results,
         }
         update_task_status(task_id, TaskStatus.FINISHED, db_name=db_name)
         logger.info("Worker finish memory_writer: task_id=%s episode_uid=%s", task_id, episode_uid)

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -45,6 +45,11 @@ from langchain_core.prompts import ChatPromptTemplate
 from openai import OpenAI
 
 try:
+    from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
+except ImportError:
+    from agent.memory.store import get_project_memory_episode, list_project_memory_episodes
+
+try:
     from agent.llm_provider import build_openai_compatible_chat_model
     from agent.settings import load_agent_settings
 except ImportError:
@@ -374,3 +379,42 @@ def task_generate_mindmap(task_id: str, file_path: str, uid: str, user_uuid: str
         update_task_status(task_id, TaskStatus.FAILED, error_message=error_msg)
         logger.exception("Worker failed mindmap: task_id=%s", task_id)
         return False, None
+
+
+def task_memory_writer(
+    task_id: str,
+    episode_uid: str,
+    user_uuid: str,
+    *,
+    db_name: str = "./database.sqlite",
+    context_limit: int = 5,
+):
+    try:
+        logger.info("Worker start memory_writer: task_id=%s episode_uid=%s", task_id, episode_uid)
+        update_task_status(task_id, TaskStatus.STARTED, db_name=db_name)
+
+        episode = get_project_memory_episode(episode_uid=episode_uid, db_name=db_name)
+        if not episode:
+            error_msg = "memory episode not found"
+            update_task_status(task_id, TaskStatus.FAILED, error_message=error_msg, db_name=db_name)
+            return False, error_msg
+
+        recent_episodes = list_project_memory_episodes(
+            uuid=user_uuid,
+            project_uid=str(episode.get("project_uid") or ""),
+            session_uid=str(episode.get("session_uid") or ""),
+            limit=max(1, int(context_limit)),
+            db_name=db_name,
+        )
+        payload = {
+            "episode": episode,
+            "recent_episodes": recent_episodes,
+        }
+        update_task_status(task_id, TaskStatus.FINISHED, db_name=db_name)
+        logger.info("Worker finish memory_writer: task_id=%s episode_uid=%s", task_id, episode_uid)
+        return True, payload
+    except Exception as e:
+        error_msg = str(e)
+        update_task_status(task_id, TaskStatus.FAILED, error_message=error_msg, db_name=db_name)
+        logger.exception("Worker failed memory_writer: task_id=%s episode_uid=%s", task_id, episode_uid)
+        return False, error_msg

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -436,6 +436,7 @@ def task_memory_writer(
             recent_episodes=recent_episodes,
             active_memories=active_memories,
             user_uuid=user_uuid,
+            db_name=db_name,
         )
         reconcile_results = apply_memory_candidates(
             uuid=user_uuid,

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -20,24 +20,6 @@ from agent.application.language import detect_language as _detect_language
 from agent.application.runtime_tuning import apply_runtime_tuning_env
 from agent.llm_provider import build_openai_compatible_chat_model
 from agent.logging_utils import configure_application_logging
-from agent.memory.store import (
-    get_project_session_compact_memory as _memory_store_get_project_session_compact_memory,
-)
-from agent.memory.store import (
-    list_project_memory_items as _memory_store_list_project_memory_items,
-)
-from agent.memory.store import (
-    save_project_session_compact_memory as _memory_store_save_project_session_compact_memory,
-)
-from agent.memory.store import (
-    search_project_memory_items as _memory_store_search_project_memory_items,
-)
-from agent.memory.store import (
-    touch_memory_items as _memory_store_touch_memory_items,
-)
-from agent.memory.store import (
-    upsert_project_memory_item as _memory_store_upsert_project_memory_item,
-)
 from agent.settings import load_agent_settings
 
 from .schemas import FileRecord
@@ -389,109 +371,6 @@ def save_project_session_messages(
         project_uid=project_uid,
         uuid=uuid,
         messages=messages,
-        db_name=db_name,
-    )
-
-
-def get_project_session_compact_memory(
-    session_uid: str,
-    project_uid: str,
-    uuid: str,
-    db_name: str = "./database.sqlite",
-) -> dict[str, Any]:
-    return _memory_store_get_project_session_compact_memory(
-        session_uid=session_uid,
-        project_uid=project_uid,
-        uuid=uuid,
-        db_name=db_name,
-    )
-
-
-def save_project_session_compact_memory(
-    session_uid: str,
-    project_uid: str,
-    uuid: str,
-    compact_summary: str,
-    anchors: list[dict[str, Any]] | None = None,
-    db_name: str = "./database.sqlite",
-) -> None:
-    _memory_store_save_project_session_compact_memory(
-        session_uid=session_uid,
-        project_uid=project_uid,
-        uuid=uuid,
-        compact_summary=compact_summary,
-        anchors=anchors,
-        db_name=db_name,
-    )
-
-
-def upsert_project_memory_item(
-    *,
-    uuid: str,
-    project_uid: str,
-    session_uid: str | None,
-    memory_type: str,
-    content: str,
-    title: str = "",
-    source_prompt: str = "",
-    source_answer: str = "",
-    expires_at: str = "",
-    db_name: str = "./database.sqlite",
-) -> str:
-    return _memory_store_upsert_project_memory_item(
-        uuid=uuid,
-        project_uid=project_uid,
-        session_uid=session_uid,
-        memory_type=memory_type,
-        content=content,
-        title=title,
-        source_prompt=source_prompt,
-        source_answer=source_answer,
-        expires_at=expires_at,
-        db_name=db_name,
-    )
-
-
-def list_project_memory_items(
-    *,
-    uuid: str,
-    project_uid: str,
-    memory_type: str | None = None,
-    limit: int = 100,
-    include_expired: bool = False,
-    db_name: str = "./database.sqlite",
-) -> list[dict[str, Any]]:
-    return _memory_store_list_project_memory_items(
-        uuid=uuid,
-        project_uid=project_uid,
-        memory_type=memory_type,
-        limit=limit,
-        include_expired=include_expired,
-        db_name=db_name,
-    )
-
-
-def touch_memory_items(
-    *,
-    memory_uids: list[str],
-    db_name: str = "./database.sqlite",
-) -> None:
-    _memory_store_touch_memory_items(memory_uids=memory_uids, db_name=db_name)
-
-
-def search_project_memory_items(
-    *,
-    uuid: str,
-    project_uid: str,
-    query: str,
-    limit: int = 5,
-    db_name: str = "./database.sqlite",
-) -> list[dict[str, Any]]:
-    return _memory_store_search_project_memory_items(
-        uuid=uuid,
-        project_uid=project_uid,
-        query=query,
-        limit=limit,
         db_name=db_name,
     )
 


### PR DESCRIPTION
## Why

当前项目的长期记忆仍以截断后的 `Q/A` 文本片段为主存储形态，并通过关键词重叠与时间衰减进行检索。这种实现无法稳定支持用户偏好、论文事实、项目知识等长期记忆场景，也缺少结构化更新、冲突处理和可靠去重能力。

随着项目向多 Agent、长会话和项目级知识沉淀演进，记忆系统需要从“对话片段缓存”升级为“异步、结构化、可对账的长期记忆管线”，避免主链路阻塞，并让记忆具备可追溯、可更新、可检索的工程属性。

## What Changes

- 将现有同步 `persist_turn_memory` 逻辑改造为“原始 episode 落盘 + 异步 memory job 投递”的双阶段流程
- 新增长期记忆结构化抽取流程，区分用户偏好/指令类记忆与知识类记忆
- 新增记忆对账与生命周期动作，支持 `ADD`、`UPDATE`、`DELETE`、`NONE`、`SUPERSEDE`
- 为长期记忆补充 canonical text、dedup key、evidence、confidence、status 等结构化字段
- 将长期记忆检索从关键词优先改为类型化检索与语义召回优先
- 调整 prompt 注入策略，对用户记忆与知识记忆采用不同注入位置与优先级
- 替换并移除旧的同步片段写入、关键词主检索与仅透传式兼容入口，避免新旧主链路长期并存
- **BREAKING**: 长期记忆的主链路语义将从“聊天片段存储/搜索”切换为“结构化 memory item 管理/检索”

## Capabilities

### New Capabilities

- `agentic-memory-system`: 定义长期记忆的异步抽取、结构化存储、去重对账、状态迁移与类型化检索能力

### Modified Capabilities

<!-- 无现有 capability 需要修改 -->

## Impact

**代码影响**:
- `agent/application/agent_center/memory.py` - 从同步对话片段写入切换到 episode 持久化与异步任务投递
- `agent/application/agent_center/page_orchestrator.py` - 对话完成后触发 memory pipeline
- `agent/memory/repository.py` - 扩展记忆表结构，新增 episode / evidence / lifecycle 支持
- `agent/memory/service.py` - 重构长期记忆检索与对账逻辑
- `agent/memory/store.py` / `utils/utils.py` - 清理旧的 memory facade 与兼容入口
- `agent/application/agent_center/controller.py` - 按记忆类型调整 prompt 注入策略
- `utils/task_queue.py` / `utils/tasks.py` - 新增异步 memory writer 任务

**数据影响**:
- 新增长期记忆相关结构化字段与原始 episode 数据
- 现有 `memory_items` 数据模型需要迁移或兼容读取
- 记忆检索索引和 dedup key 需要持久化维护

**依赖与运行时影响**:
- 复用现有异步任务基础设施，不要求新增外部队列服务
- 需要引入或复用 embedding / rerank 能力支撑语义召回
- 异步 memory job 的失败、重试、幂等需要纳入运行时治理