### PR TITLE
feat: add Tavily as top-priority web search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@ AGENT_VECTORSTORE_PERSIST_DIR=./.cache/vector_db
 # =========================
 # Tooling / web search (optional)
 # =========================
+TAVILY_API_KEY=
 BRAVE_SEARCH_API_KEY=
 AGENT_SEARXNG_BASE_URLS=
 AGENT_WEB_ENABLE_DDG_FALLBACK=0

--- a/agent/tools/web_search.py
+++ b/agent/tools/web_search.py
@@ -41,6 +41,38 @@ def _parse_searxng_instances() -> list[str]:
     return [item.rstrip("/") for item in DEFAULT_SEARXNG_INSTANCES]
 
 
+def _build_tavily_web_search_client():
+    api_key = _load_secret("TAVILY_API_KEY")
+    if not api_key:
+        return None
+
+    class _TavilyWebSearch:
+        def __init__(self, key: str):
+            from tavily import TavilyClient
+
+            self._client = TavilyClient(api_key=key)
+
+        def run(self, query: str) -> str:
+            response = self._client.search(
+                query=query,
+                max_results=DEFAULT_WEB_MAX_RESULTS,
+                search_depth="basic",
+            )
+            results = response.get("results") if isinstance(response, dict) else None
+            return _format_web_results(
+                results,
+                title_key="title",
+                url_key="url",
+                snippet_key="content",
+            )
+
+    try:
+        return _TavilyWebSearch(api_key)
+    except Exception as exc:
+        logger.warning("tool.search_web tavily client init failed: %s", exc)
+        return None
+
+
 def _build_brave_web_search_client():
     api_key = _load_secret("BRAVE_SEARCH_API_KEY")
     if not api_key:
@@ -211,6 +243,11 @@ def _ensure_web_search_clients() -> list[tuple[str, Any]]:
         return _web_search_clients
 
     clients: list[tuple[str, Any]] = []
+
+    tavily_client = _build_tavily_web_search_client()
+    if tavily_client is not None:
+        clients.append(("tavily_search_api", tavily_client))
+        logger.info("tool.search_web provider initialized: tavily_search_api")
 
     brave_client = _build_brave_web_search_client()
     if brave_client is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ redis>=5.0.0
 rq>=1.15.0
 rank-bm25>=1.0.0
 jieba>=0.42.0
+tavily-python>=0.5.0


### PR DESCRIPTION
## Summary

- Added Tavily as a configurable, highest-priority web search provider in the multi-provider chain
- When `TAVILY_API_KEY` is set, Tavily is tried first before all existing providers
- All existing providers (Brave, SearXNG, Wikipedia, DuckDuckGo) remain untouched as fallbacks
- If `TAVILY_API_KEY` is absent, behavior is identical to before this change

## Files changed

- **`agent/tools/web_search.py`** — Added `_build_tavily_web_search_client()` using the `tavily-python` SDK; prepended Tavily client in `_ensure_web_search_clients()` provider list
- **`requirements.txt`** — Added `tavily-python>=0.5.0`
- **`.env.example`** — Added `TAVILY_API_KEY=` under the Tooling / web search section

## Dependency changes

- Added `tavily-python>=0.5.0` to `requirements.txt`

## Environment variable changes

- Added `TAVILY_API_KEY` (optional) — enables Tavily as the top-priority search provider

## Notes for reviewers

- Provider priority is now: Tavily → Brave → SearXNG → Wikipedia → DuckDuckGo
- The Tavily client import happens lazily inside the class constructor to avoid import errors when the package is not installed
- Uses `_format_web_results` with `title/url/content` keys which are already compatible with Tavily result dicts
- Client initialization failure is caught and logged, falling through to next provider


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is correct, complete, and consistent with the existing codebase. All three expected files are updated, SDK usage is accurate, response key mapping matches the Tavily API, and the fallback chain is fully preserved. One minor pre-existing UX issue: the "no provider available" error message doesn't mention TAVILY_API_KEY, but this was not introduced by this change.
