### PR TITLE
chore: prepare v1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-31
+
+### Added
+- Cross-platform Electron packaging, installer checksums, and GitHub build provenance for the workspace application.
+
+### Changed
+- Migrated the web workspace and release workflows from npm to pnpm.
+
 ## [1.1.0] - 2026-03-22
 
 ## [1.0.5] - 2026-03-16
@@ -79,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 53 unit tests + 6 integration tests + eval baselines
 - CLI entry point: `paper-sage`
 
-[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/0verL1nk/PaperSage/compare/v1.1.0...v1.1.1
 [1.0.0]: https://github.com/0verL1nk/PaperSage/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/0verL1nk/PaperSage/releases/tag/v0.1.0
 [1.0.1]: https://github.com/0verL1nk/PaperSage/compare/v1.0.0...v1.0.1

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.0"
+version = "1.1.1"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "scripts": {


### PR DESCRIPTION
## Background
The v1.1.0 tag already exists, so the merged desktop and pnpm changes need a new, traceable release version.

## Changes
- Align Python, agent, and desktop versions at 1.1.1.
- Regenerate the Python lock metadata.
- Document the desktop release and pnpm migration in the changelog.

## Risk and rollback
Low-risk metadata-only change. Revert this commit before tagging if needed.

## Validation
- Python unit tests: 243 passed.
- Frontend TypeScript: passed.
- Frontend Vitest: 7 files / 14 tests passed.