### PR TITLE
fix: declare Electron package entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-31
+
+### Fixed
+- Declared the Electron main-process entry point so native installers can pass Electron Builder's package integrity check.
+
 ## [1.1.1] - 2026-07-31
 
 ### Added
@@ -87,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 53 unit tests + 6 integration tests + eval baselines
 - CLI entry point: `paper-sage`
 
-[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/0verL1nk/PaperSage/compare/v1.1.0...v1.1.1
 [1.0.0]: https://github.com/0verL1nk/PaperSage/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/0verL1nk/PaperSage/releases/tag/v0.1.0

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.1"
+version = "1.1.2"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,8 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
+  "main": "electron/main.cjs",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "scripts": {


### PR DESCRIPTION
## Background
Desktop Release v1.1.1 failed on every platform because Electron Builder fell back to an undeclared index.js entry.

## Changes
- Declare electron/main.cjs as the Electron package entry.
- Bump Python, agent, and desktop versions to 1.1.2.
- Record the packaging fix in the changelog.

## Risk and rollback
Metadata/configuration-only change. Revert this commit if packaging regresses.

## Validation
- Local Windows NSIS installer generated successfully.
- SHA-256: 7a29e8ae125bd0476cbd9db4b332003c510dc561d52ec7695f8a4c0b4242f20f.
- Python unit tests: 243 passed.
- Frontend TypeScript: passed.
- Frontend Vitest: 7 files / 14 tests passed.