### PR TITLE
fix: repair cross-platform desktop release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -77,12 +77,21 @@ jobs:
           }
 
       - name: Build installer
+        shell: pwsh
         run: |
+          if ("${{ matrix.name }}" -eq "macOS") {
+            if ($env:MAC_CSC_LINK) {
+              $env:CSC_LINK = $env:MAC_CSC_LINK
+              $env:CSC_KEY_PASSWORD = $env:MAC_CSC_KEY_PASSWORD
+            } else {
+              $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
+            }
+          }
           pnpm --dir web run ${{ matrix.command }}
           pnpm --dir web run desktop:checksums
         env:
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-08-01
+
+### Fixed
+- Added required Electron package metadata for Linux packages and skipped macOS signing cleanly when no signing certificate is configured.
+
 ## [1.1.2] - 2026-07-31
 
 ### Fixed
@@ -92,7 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 53 unit tests + 6 integration tests + eval baselines
 - CLI entry point: `paper-sage`
 
-[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/0verL1nk/PaperSage/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/0verL1nk/PaperSage/compare/v1.1.0...v1.1.1
 [1.0.0]: https://github.com/0verL1nk/PaperSage/compare/v0.1.0...v1.0.0

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.2"
+version = "1.1.3"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,15 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
+  "description": "AI research workspace for scholarly reading and writing.",
+  "author": "PaperSage Contributors",
+  "homepage": "https://github.com/0verL1nk/PaperSage",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0verL1nk/PaperSage.git"
+  },
+  "license": "MIT",
   "main": "electron/main.cjs",
   "type": "module",
   "packageManager": "pnpm@11.18.0",


### PR DESCRIPTION
## Background
The v1.1.2 desktop release built Windows successfully but failed on Linux and macOS, so installer assets were not published.

## Root cause
- Linux Electron Builder requires homepage metadata.
- macOS received an empty CSC_LINK and treated the repository directory as a certificate file.

## Changes
- Add package metadata required by Electron Builder.
- Import macOS signing credentials only when configured; otherwise explicitly build unsigned.
- Bump the release version to 1.1.3 because v1.1.2 is immutable.

## Risk and rollback
Configuration and release metadata only. Revert the commit before tagging if packaging regresses.

## Validation
- Python unit tests: 243 passed.
- Frontend TypeScript: passed.
- Frontend Vitest: 7 files / 14 tests passed.
- Release workflow YAML: parsed successfully.