### PR TITLE
fix: publish Linux deb package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-08-01
+
+### Fixed
+- Added the required maintainer metadata so Linux releases include both AppImage and DEB packages.
+
 ## [1.1.3] - 2026-08-01
 
 ### Fixed
@@ -97,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 53 unit tests + 6 integration tests + eval baselines
 - CLI entry point: `paper-sage`
 
-[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/0verL1nk/PaperSage/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/0verL1nk/PaperSage/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/0verL1nk/PaperSage/compare/v1.1.0...v1.1.1

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.3"
+version = "1.1.4"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "AI research workspace for scholarly reading and writing.",
   "author": "PaperSage Contributors",
   "homepage": "https://github.com/0verL1nk/PaperSage",
@@ -91,7 +91,11 @@
     "extraResources": [{ "from": ".desktop-backend", "to": "backend" }],
     "win": { "target": ["nsis"] },
     "mac": { "target": ["dmg"], "category": "public.app-category.productivity" },
-    "linux": { "target": ["AppImage", "deb"], "category": "Office" },
+    "linux": {
+      "target": ["AppImage", "deb"],
+      "category": "Office",
+      "maintainer": "PaperSage Contributors <0verL1nk@users.noreply.github.com>"
+    },
     "nsis": { "oneClick": false, "allowToChangeInstallationDirectory": true }
   }
 }


### PR DESCRIPTION
## Background
The v1.1.3 release published Windows, macOS, and Linux AppImage assets, but the requested Linux DEB asset was absent.

## Root cause
Electron Builder requires Linux DEB maintainer metadata. The AppImage completed first, so the job did not prevent the partial release.

## Changes
- Set the Linux package maintainer metadata required for DEB generation.
- Bump all release versions to 1.1.4 because v1.1.3 is immutable.

## Risk and rollback
Release metadata only. Revert the commit before tagging if packaging regresses.

## Validation
- Python unit tests: 243 passed.
- Frontend TypeScript: passed.
- Frontend Vitest: 7 files / 14 tests passed.
- package.json parsed successfully.