### PR TITLE
fix: consolidate release assets

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,7 +24,7 @@ jobs:
             artifact: PaperSage-Windows
             files: |
               web/release/*.exe
-              web/release/*.yml
+              web/release/latest.yml
               web/release/*.blockmap
           - name: macOS
             os: macos-latest
@@ -33,7 +33,7 @@ jobs:
             files: |
               web/release/*.dmg
               web/release/*.zip
-              web/release/*.yml
+              web/release/latest-mac.yml
               web/release/*.blockmap
           - name: Linux
             os: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
             files: |
               web/release/*.AppImage
               web/release/*.deb
-              web/release/*.yml
+              web/release/latest-linux.yml
               web/release/*.blockmap
     steps:
       - uses: actions/checkout@v6
@@ -98,21 +98,11 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      - name: Attest release packages
-        if: github.event.repository.private == false
-        uses: actions/attest@v4
-        with:
-          subject-path: |
-            ${{ matrix.files }}
-            web/release/SHA256SUMS.txt
-
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}-${{ github.ref_name }}
-          path: |
-            ${{ matrix.files }}
-            web/release/SHA256SUMS.txt
+          path: ${{ matrix.files }}
           if-no-files-found: error
           retention-days: 14
 
@@ -126,8 +116,36 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           path: release
+
+      - name: Consolidate release assets
+        shell: pwsh
+        run: |
+          $outputDirectory = Join-Path $PWD "release-assets"
+          New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+          $assets = Get-ChildItem -Path "release" -Recurse -File
+          foreach ($asset in $assets) {
+            $destination = Join-Path $outputDirectory $asset.Name
+            if (Test-Path $destination) {
+              throw "Duplicate release asset name: $($asset.Name)"
+            }
+            Copy-Item -LiteralPath $asset.FullName -Destination $destination
+          }
+          $checksums = Get-ChildItem -Path $outputDirectory -File |
+            Sort-Object Name |
+            ForEach-Object {
+              $hash = Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256
+              "$($hash.Hash.ToLowerInvariant())  $($_.Name)"
+            }
+          Set-Content -LiteralPath (Join-Path $outputDirectory "SHA256SUMS.txt") -Value $checksums
+
+      - name: Attest consolidated release assets
+        if: github.event.repository.private == false
+        uses: actions/attest@v4
+        with:
+          subject-path: release-assets/*
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: release/**/*
+          files: release-assets/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-08-01
+
+### Fixed
+- Consolidated release assets before publishing to avoid duplicate checksum and debug-file names across platforms.
+
 ## [1.1.4] - 2026-08-01
 
 ### Fixed
@@ -102,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 53 unit tests + 6 integration tests + eval baselines
 - CLI entry point: `paper-sage`
 
-[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/0verL1nk/PaperSage/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/0verL1nk/PaperSage/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/0verL1nk/PaperSage/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/0verL1nk/PaperSage/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/0verL1nk/PaperSage/compare/v1.1.1...v1.1.2

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.4"
+version = "1.1.5"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "AI research workspace for scholarly reading and writing.",
   "author": "PaperSage Contributors",
   "homepage": "https://github.com/0verL1nk/PaperSage",


### PR DESCRIPTION
## Background
All v1.1.4 native packages built successfully, including the Linux DEB, but the final release publication failed while uploading duplicate platform-local checksum and debug assets.

## Changes
- Upload only unique platform package, blockmap, and updater assets.
- Consolidate assets in the publish job and generate one global SHA256SUMS.txt.
- Attest the final consolidated assets and bump the release version to 1.1.5.

## Risk and rollback
Release workflow and metadata only. Revert before tagging if the publish flow regresses.

## Validation
- Release workflow YAML parsed successfully.
- Python unit tests: 243 passed.
- Frontend TypeScript: passed.
- Frontend Vitest: 7 files / 14 tests passed.