### PR TITLE
fix: refine desktop workspace navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-08-01
+
+### Fixed
+- Kept the active project available when opening global settings, with a direct return path to the project workspace.
+- Contained Electron scrolling in the workspace and applied the product scrollbar treatment to native overflow regions.
+
 ## [1.1.5] - 2026-08-01
 
 ### Fixed

--- a/docs/architecture/desktop-application.md
+++ b/docs/architecture/desktop-application.md
@@ -10,4 +10,6 @@ Electron is intentionally limited to `web/electron/`:
 
 `make desktop-dev` runs Vite plus the Electron shell. `make desktop-package-win`, `make desktop-package-mac`, and `make desktop-package-linux` build the shared web bundle, package the Python server with its `web/dist` resources, then produce NSIS, DMG, or AppImage/deb on their native operating system. Never add desktop-only business logic to pages or React components; add narrowly scoped capabilities to the preload bridge and platform module instead.
 
+In Electron, the app shell owns the viewport: the document itself never scrolls, while the central content region provides the single application scroller. Native overflow inside sheets and code blocks uses the same thin themed scrollbar; persistent navigation panes continue to use Radix `ScrollArea`.
+
 GitHub Actions uses the same native package commands for tagged releases. It builds Windows, macOS, and Linux artifacts on their respective runners, then attaches the generated packages and update metadata to the GitHub Release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.5"
+version = "1.1.6"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "AI research workspace for scholarly reading and writing.",
   "author": "PaperSage Contributors",
   "homepage": "https://github.com/0verL1nk/PaperSage",

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router"
 import { BookOpen, ChevronDown, Menu, MessageSquarePlus, Settings } from "lucide-react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { ResearchSessionList } from "@/components/research-session-list"
@@ -41,7 +42,9 @@ function WorkspaceSidebar({ includeBrand = false }: { includeBrand?: boolean }) 
   const pathname = useRouterState({ select: (state) => state.location.pathname })
   const navigate = useNavigate()
   const projects = useProjects()
-  const projectId = pathname.match(/^\/projects\/([^/]+)/)?.[1]
+  const routeProjectId = pathname.match(/^\/projects\/([^/]+)/)?.[1]
+  const rememberedProjectId = useUiStore((state) => state.currentProjectId)
+  const projectId = routeProjectId ?? rememberedProjectId
   const currentProject = projects.data?.find((project) => project.project_uid === projectId)
   const sessions = useSessions(projectId ?? "", Boolean(projectId))
   const createSession = useCreateSession(projectId ?? "")
@@ -59,10 +62,23 @@ function WorkspaceSidebar({ includeBrand = false }: { includeBrand?: boolean }) 
 }
 
 export function AppShell() {
-  const { mobileNavOpen, setMobileNavOpen } = useUiStore()
+  const { mobileNavOpen, setMobileNavOpen, setCurrentProjectId } = useUiStore()
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
   const desktop = Boolean(desktopWindowControls())
+  const routeProjectId = pathname.match(/^\/projects\/([^/]+)/)?.[1]
+
+  useEffect(() => {
+    if (routeProjectId) setCurrentProjectId(routeProjectId)
+  }, [routeProjectId, setCurrentProjectId])
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle("desktop-app", desktop)
+    return () => root.classList.remove("desktop-app")
+  }, [desktop])
+
   return (
-    <div className="min-h-screen bg-background">
+    <div className={cn("bg-background", desktop ? "h-dvh overflow-hidden" : "min-h-screen")}>
       <DesktopTitlebar />
       <aside className={cn("fixed bottom-0 left-0 z-40 hidden w-64 border-r bg-sidebar p-3 md:flex md:flex-col", desktop ? "top-9" : "top-0")}>
         <WorkspaceSidebar includeBrand />
@@ -81,7 +97,7 @@ export function AppShell() {
           <div className="border-t pt-3"><Navigation /></div>
         </SheetContent>
       </Sheet>
-      <main className={cn("md:pl-64", desktop && "pt-9")}><Outlet /></main>
+      <main className={cn("min-w-0 md:pl-64", desktop && "h-dvh overflow-y-auto overscroll-contain pt-9")}><Outlet /></main>
     </div>
   )
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -127,8 +127,42 @@
     @apply bg-background text-foreground antialiased;
     min-width: 320px;
     }
-  html {
-    @apply font-sans;
+    html {
+        @apply font-sans;
+    }
+
+    /* Electron has one deliberate document scroller. Nested overflow regions
+       retain their semantics but share the product's restrained scrollbar. */
+    html.desktop-app,
+    html.desktop-app body,
+    html.desktop-app #root {
+        height: 100%;
+        overflow: hidden;
+    }
+
+    html.desktop-app * {
+        scrollbar-color: color-mix(in oklch, var(--muted-foreground) 52%, transparent) transparent;
+        scrollbar-width: thin;
+    }
+
+    html.desktop-app ::-webkit-scrollbar {
+        width: 0.625rem;
+        height: 0.625rem;
+    }
+
+    html.desktop-app ::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    html.desktop-app ::-webkit-scrollbar-thumb {
+        border: 0.1875rem solid transparent;
+        border-radius: 999px;
+        background-clip: padding-box;
+        background-color: color-mix(in oklch, var(--muted-foreground) 52%, transparent);
+    }
+
+    html.desktop-app ::-webkit-scrollbar-thumb:hover {
+        background-color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
     }
 }
 

--- a/web/src/pages/settings-page.tsx
+++ b/web/src/pages/settings-page.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { CheckCircle2, Database, LockKeyhole, Save, ServerCog } from "lucide-react"
+import { Link } from "@tanstack/react-router"
+import { ArrowLeft, CheckCircle2, Database, LockKeyhole, Save, ServerCog } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
@@ -16,6 +17,7 @@ import { Label } from "@/components/ui/label"
 import { api } from "@/lib/api"
 import { keys, useSettings } from "@/lib/queries"
 import { settingsSchema } from "@/lib/schemas"
+import { useUiStore } from "@/stores/ui-store"
 
 const formSchema = z.object({
   api_key: z.string(),
@@ -32,6 +34,7 @@ function FieldError({ message }: { message?: string }) {
 }
 
 export function SettingsPage() {
+  const currentProjectId = useUiStore((state) => state.currentProjectId)
   const query = useSettings()
   const client = useQueryClient()
   const form = useForm<SettingsForm>({
@@ -67,7 +70,7 @@ export function SettingsPage() {
   const configured = query.data?.api_key_configured
   return <div className="mx-auto w-full max-w-3xl px-5 py-10 lg:px-8">
     <header className="mb-9 space-y-3">
-      <PaperSageBrand className="text-sm text-muted-foreground" />
+      <div className="flex items-center justify-between gap-4"><PaperSageBrand className="text-sm text-muted-foreground" />{currentProjectId && <Button variant="ghost" size="sm" asChild><Link to="/projects/$projectId" params={{ projectId: currentProjectId }}><ArrowLeft />返回项目</Link></Button>}</div>
       <div><h1 className="text-3xl font-semibold tracking-tight">设置</h1><p className="mt-2 text-sm leading-6 text-muted-foreground">配置用于研究和资料库的模型连接。密钥只保存于服务端，已保存的值不会回传到浏览器。</p></div>
     </header>
 
@@ -92,7 +95,7 @@ export function SettingsPage() {
         </CardContent>
       </Card>
 
-      <div className="fixed inset-x-0 bottom-0 z-20 border-t bg-background/95 px-5 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80"><div className="mx-auto flex max-w-3xl items-center justify-between gap-4"><p className="hidden text-xs text-muted-foreground sm:block">配置变更不会中断已经开始的研究。</p><Button type="submit" className="ml-auto" disabled={save.isPending || !form.formState.isDirty}><Save className="size-4" />{save.isPending ? "保存中…" : "保存设置"}</Button></div></div>
+      <div className="sticky bottom-0 z-20 -mx-5 border-t bg-background/95 px-5 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-8 lg:px-8"><div className="mx-auto flex max-w-3xl items-center justify-between gap-4"><p className="hidden text-xs text-muted-foreground sm:block">配置变更不会中断已经开始的研究。</p><Button type="submit" className="ml-auto" disabled={save.isPending || !form.formState.isDirty}><Save className="size-4" />{save.isPending ? "保存中…" : "保存设置"}</Button></div></div>
     </form>
   </div>
 }

--- a/web/src/stores/ui-store.test.ts
+++ b/web/src/stores/ui-store.test.ts
@@ -1,0 +1,13 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { useUiStore } from "@/stores/ui-store"
+
+describe("ui store", () => {
+  afterEach(() => useUiStore.setState({ currentProjectId: "" }))
+
+  it("keeps the active project available while visiting a global page", () => {
+    useUiStore.getState().setCurrentProjectId("project-123")
+
+    expect(useUiStore.getState().currentProjectId).toBe("project-123")
+  })
+})

--- a/web/src/stores/ui-store.ts
+++ b/web/src/stores/ui-store.ts
@@ -3,19 +3,23 @@ import { create } from "zustand"
 type InspectorTab = "evidence" | "activity" | "plan" | "context"
 
 interface UiState {
+  currentProjectId: string
   mobileNavOpen: boolean
   inspectorOpen: boolean
   inspectorTab: InspectorTab
   setMobileNavOpen: (open: boolean) => void
+  setCurrentProjectId: (projectId: string) => void
   openInspector: (tab: InspectorTab) => void
   setInspectorOpen: (open: boolean) => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
+  currentProjectId: "",
   mobileNavOpen: false,
   inspectorOpen: false,
   inspectorTab: "evidence",
   setMobileNavOpen: (mobileNavOpen) => set({ mobileNavOpen }),
+  setCurrentProjectId: (currentProjectId) => set({ currentProjectId }),
   openInspector: (inspectorTab) => set({ inspectorOpen: true, inspectorTab }),
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
 }))


### PR DESCRIPTION
## 背景
桌面端仍显示 Chromium 原生滚动条；进入全局设置后，侧栏失去当前项目上下文，容易误以为项目消失。

## 改动
- 由桌面应用壳层统一承载滚动，并为原生溢出区域使用主题滚动条。
- 保留当前项目上下文；设置页提供“返回项目”，保存操作固定在内容流内。
- 增加状态回归测试，并同步文档、变更日志和 v1.1.6 版本号。

## 风险与回滚
仅涉及共享 React 壳层、设置页和 CSS。回滚此提交即可恢复先前行为。

## 验证
- `tsc -b --pretty false`
- `vitest run`（8 文件 / 15 测试）
- `vite build`
- API 健康检查与项目列表接口均返回 200

已知：本地 ESLint 受锁定的 TypeScript 7.0 与 typescript-eslint 8.65.0 不兼容而无法启动；与本次改动无关。