### PR TITLE
fix: align PyPI package version

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -154,6 +154,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${{ github.ref_name }}" `
             release-assets/latest.yml `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-08-01
+
+### Fixed
+- Kept the runtime package version aligned with Python package metadata so tagged PyPI releases can publish successfully.
+
 ## [1.1.8] - 2026-08-01
 
 ### Fixed

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.5"
+__version__ = "1.1.9"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.8"
+version = "1.1.9"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/tests/unit/test_package_version.py
+++ b/tests/unit/test_package_version.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import tomllib
+from pathlib import Path
 
 from agent import __version__
 

--- a/tests/unit/test_package_version.py
+++ b/tests/unit/test_package_version.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+from agent import __version__
+
+
+def test_runtime_version_matches_package_metadata() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    package_metadata = tomllib.loads((project_root / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert __version__ == package_metadata["project"]["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -2703,7 +2703,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "AI research workspace for scholarly reading and writing.",
   "author": "PaperSage Contributors",
   "homepage": "https://github.com/0verL1nk/PaperSage",


### PR DESCRIPTION
PyPI release validation read agent.__version__ (1.1.5) while the tag and package metadata were newer. This aligns all runtime and package versions to 1.1.9 and adds a regression test. Verified with the focused pytest and uv build.