### PR TITLE
ci: skip AI review when credentials are unavailable

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,10 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
       (github.event_name == 'pull_request')
     runs-on: ubuntu-latest
+    # A missing optional AI-review credential must not make ordinary PR checks
+    # fail, including Dependabot and forked pull requests.
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: write
       pull-requests: write
@@ -76,6 +80,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Forks and Dependabot runs do not receive repository secrets. Keep the
+    # required review check green when the optional AI reviewer is unavailable.
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     permissions:
       contents: write
       pull-requests: write
@@ -41,6 +45,7 @@ jobs:
           fi
 
       - name: PR Review with Progress Tracking
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Root cause: the optional Claude review action ran for Dependabot and fork PRs even though GitHub does not provide repository secrets to those runs, causing credential-validation failures. Change: gate both Claude Code workflow actions on a non-empty ANTHROPIC_API_KEY while leaving quality and unit-test checks unchanged. AI review remains enabled when the credential exists; reverting this commit restores former behavior. Verified workflow YAML parsing, Ruff, ty, 244 unit tests, and git diff --check.