### PR TITLE
chore(deps): resolve frontend security alerts

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
     "class-variance-authority": "latest",
     "clsx": "latest",
     "cmdk": "^1.1.1",
-    "electron-updater": "6.8.5",
+    "electron-updater": "6.8.9",
     "embla-carousel-react": "^8.6.0",
     "katex": "^0.18.1",
     "lucide-react": "latest",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       electron-updater:
-        specifier: 6.8.5
-        version: 6.8.5
+        specifier: 6.8.9
+        version: 6.8.9
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.8)
@@ -2735,8 +2735,8 @@ packages:
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
-  electron-updater@6.8.5:
-    resolution: {integrity: sha512-7f9mHKqrlhpp65vM1MmXD6Xs0l3UnKs4Vn/VfrseldIW7fsrS/8H+Wn0DU5AURL89X74e0Y/yVD5tSaAsrjCyA==}
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
@@ -2953,8 +2953,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -7139,7 +7139,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7697,9 +7697,9 @@ snapshots:
 
   electron-to-chromium@1.5.393: {}
 
-  electron-updater@6.8.5:
+  electron-updater@6.8.9:
     dependencies:
-      builder-util-runtime: 9.6.0
+      builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
       js-yaml: 4.3.0
       lazy-val: 1.0.5
@@ -7987,7 +7987,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
Updates electron-updater from 6.8.5 to 6.8.9, which upgrades its pinned builder-util-runtime dependency from 9.6.0 to 9.7.0. Also updates the compatible fast-uri transitive patch from 3.1.4 to 3.1.5. The remaining undici alert comes from node-gyp's incompatible 6.x constraint and is intentionally not forced to 7.x. Verified in an isolated worktree with pnpm install --frozen-lockfile, typecheck, tests, production build, and git diff --check.