### PR TITLE
chore(release): prepare v1.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.11] - 2026-08-08
+
+### Fixed
+- Updated Python and frontend dependencies to address reported security advisories and regenerated Python requirements from the canonical uv lockfile.
+- Made optional Claude-based PR review skip cleanly when repository credentials are unavailable, so Dependabot and forked PRs retain reliable quality gates.
+
 ## [1.1.10] - 2026-08-02
 
 ### Fixed

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.10"
+__version__ = "1.1.11"
 
 from .archive import list_agent_outputs, save_agent_output
 from .llm_provider import build_openai_compatible_chat_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-sage"
-version = "1.1.10"
+version = "1.1.11"
 description = "AI-powered literature reading assistant with multi-agent orchestration and hybrid RAG"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -2716,7 +2716,7 @@ wheels = [
 
 [[package]]
 name = "paper-sage"
-version = "1.1.10"
+version = "1.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "papersage-web",
   "private": true,
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "AI research workspace for scholarly reading and writing.",
   "author": "PaperSage Contributors",
   "homepage": "https://github.com/0verL1nk/PaperSage",


### PR DESCRIPTION
Prepares PaperSage v1.1.11 for release. Synchronizes the Python package, web app, and uv lockfile version metadata and documents the security dependency plus CI reliability fixes. Verified with the full Python unit suite (244 passed), ty, pnpm frozen-lockfile validation, and git diff --check.