### PR TITLE
feat: replay research surfaces by identity

### DIFF
--- a/agent/application/research_workspace.py
+++ b/agent/application/research_workspace.py
@@ -356,10 +356,19 @@ def execute_research_run(
     a2ui_surface = result.get("a2ui_surface") if isinstance(result, dict) else None
     if isinstance(a2ui_surface, dict):
         messages = a2ui_surface.get("messages")
+        surface_metadata = {
+            "catalogId": a2ui_surface.get("catalogId"),
+            "surfaceId": a2ui_surface.get("surfaceId"),
+            "title": a2ui_surface.get("title"),
+        }
         if isinstance(messages, list):
             for envelope in messages:
                 if isinstance(envelope, dict):
-                    append_run_event(run_uid=run_uid, event_type="ui.a2ui", payload={"envelope": envelope})
+                    append_run_event(
+                        run_uid=run_uid,
+                        event_type="ui.a2ui",
+                        payload={"envelope": envelope, "surface": surface_metadata},
+                    )
     update_run_status(run_uid=run_uid, status="completed")
     append_run_event(
         run_uid=run_uid,

--- a/docs/architecture/a2ui.md
+++ b/docs/architecture/a2ui.md
@@ -4,7 +4,7 @@ PaperSage uses A2UI as an optional presentation layer for a completed research a
 
 ## Current contract
 
-The leader may call `present_research_surface` when a compact hierarchy materially improves understanding. The tool accepts a bounded research map only; the server validates it, builds catalog-backed envelopes compatible with the stable A2UI v0.9.1 specification, persists them beside the assistant message, and emits them as `ui.a2ui` run events.
+The leader may call `present_research_surface` when a compact hierarchy materially improves understanding. The tool accepts a bounded research map only; the server validates it, builds catalog-backed envelopes compatible with the stable A2UI v0.9.1 specification, persists them beside the assistant message, and emits them as `ui.a2ui` run events. Each event includes the validated surface identity and title, while the envelope itself remains protocol-only.
 
 The model must still return normal Markdown and `<evidence>` citations. Streamed deltas contain only that user-facing answer: the renderer never parses A2UI from model text.
 
@@ -17,8 +17,10 @@ Each map node may contain `citation_ids`, but the server retains only chunk IDs 
 - React receives validated data only. It does not execute HTML, JavaScript, CSS, SVG, arbitrary actions, or model-provided URLs.
 - Invalid surface input falls back to the normal answer; it never replaces it.
 
-## Evolution
+## Recovery and evolution
 
-The next migration adopts the stable A2UI v0.9.1 message lifecycle for multiple surfaces, incremental updates, replay snapshots, and catalog versioning. Future catalog entries such as comparison matrices or timelines must remain evidence-grounded and must not expose generic renderer capabilities to the model.
+Run events have a durable, increasing sequence number. The client replays them in order after reconnecting and keeps surfaces by `surfaceId`, so a completed or in-flight map can recover independently without re-parsing model text. `deleteSurface` removes only its matching surface.
+
+The next migration adopts a generic A2UI v0.9.1 renderer for additional catalogs, incremental updates, replay snapshots, and catalog versioning. Future catalog entries such as comparison matrices or timelines must remain evidence-grounded and must not expose generic renderer capabilities to the model.
 
 References: [A2UI specification](https://a2ui.org/specification/v0.9-a2ui/), [catalog guidance](https://a2ui.org/guides/defining-your-own-catalog/), and [renderer guidance](https://a2ui.org/guides/renderer-development/).

--- a/tests/unit/test_research_run_events.py
+++ b/tests/unit/test_research_run_events.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+from agent.application import research_workspace
+
+
+def test_research_run_emits_validated_surface_metadata(monkeypatch) -> None:
+    events: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(research_workspace, "update_run_status", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        research_workspace,
+        "append_run_event",
+        lambda **kwargs: events.append(kwargs) or kwargs,
+    )
+    monkeypatch.setattr(
+        research_workspace.research_workspace_service,
+        "execute_turn",
+        lambda **_kwargs: {
+            "a2ui_surface": {
+                "catalogId": "https://papersage.local/a2ui/catalogs/mindmap-v1.json",
+                "surfaceId": "research-map-1",
+                "title": "论文结构",
+                "messages": [{"version": "v0.9", "createSurface": {"surfaceId": "research-map-1"}}],
+            }
+        },
+    )
+
+    research_workspace.execute_research_run(
+        run_uid="run-1",
+        project_uid="project-1",
+        session_uid="session-1",
+        user_uuid="user-1",
+        prompt="梳理结构",
+    )
+
+    a2ui_event = next(event for event in events if event["event_type"] == "ui.a2ui")
+    assert a2ui_event["payload"] == {
+        "envelope": {"version": "v0.9", "createSurface": {"surfaceId": "research-map-1"}},
+        "surface": {
+            "catalogId": "https://papersage.local/a2ui/catalogs/mindmap-v1.json",
+            "surfaceId": "research-map-1",
+            "title": "论文结构",
+        },
+    }

--- a/web/src/lib/a2ui.test.ts
+++ b/web/src/lib/a2ui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { applyA2UIEnvelope, MINDMAP_CATALOG_ID, surfaceFromPersisted } from "@/lib/a2ui"
+import { applyA2UIEnvelope, applyA2UISurfaceMetadata, MINDMAP_CATALOG_ID, surfaceFromPersisted } from "@/lib/a2ui"
 
 const create = { version: "v0.9", createSurface: { surfaceId: "map-1", catalogId: MINDMAP_CATALOG_ID } }
 const components = { version: "v0.9", updateComponents: { surfaceId: "map-1", components: [{ id: "root", component: "Mindmap", data: { path: "/mindmap" } }] } }
@@ -19,8 +19,15 @@ describe("A2UI mindmap surface", () => {
   })
 
   it("reconstructs persisted event envelopes and ignores arbitrary fields", () => {
-    const surface = surfaceFromPersisted({ messages: [create, components, data], script: "alert(1)" })
+    const surface = surfaceFromPersisted({ title: "方法概览", messages: [create, components, data], script: "alert(1)" })
     expect(surface?.surfaceId).toBe("map-1")
     expect(surface?.mindmap?.label).toBe("论文")
+    expect(surface?.title).toBe("方法概览")
+  })
+
+  it("applies only matching, server-provided presentation metadata", () => {
+    const surface = [create, components, data].reduce(applyA2UIEnvelope, null)
+    expect(applyA2UISurfaceMetadata(surface, { catalogId: MINDMAP_CATALOG_ID, surfaceId: "map-1", title: "论文结构" })?.title).toBe("论文结构")
+    expect(applyA2UISurfaceMetadata(surface, { catalogId: MINDMAP_CATALOG_ID, surfaceId: "other", title: "错误标题" })?.title).toBeUndefined()
   })
 })

--- a/web/src/lib/a2ui.ts
+++ b/web/src/lib/a2ui.ts
@@ -10,6 +10,12 @@ export type A2UISurface = {
   title?: string
 }
 
+export type A2UISurfaceMetadata = {
+  catalogId?: unknown
+  surfaceId?: unknown
+  title?: unknown
+}
+
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
@@ -61,14 +67,25 @@ export function applyA2UIEnvelope(surface: A2UISurface | null, value: unknown): 
   return remove?.surfaceId === surface.surfaceId ? null : surface
 }
 
+export function applyA2UISurfaceMetadata(
+  surface: A2UISurface | null,
+  metadata: A2UISurfaceMetadata | null | undefined,
+): A2UISurface | null {
+  if (!surface || !metadata) return surface
+  const title = typeof metadata.title === "string" ? metadata.title.trim() : ""
+  return metadata.catalogId === surface.catalogId && metadata.surfaceId === surface.surfaceId && title
+    ? { ...surface, title }
+    : surface
+}
+
 export function surfaceFromPersisted(value: Record<string, unknown> | null | undefined): A2UISurface | null {
   if (!value) return null
+  const title = typeof value.title === "string" ? value.title.trim() : ""
   const messages = Array.isArray(value.messages) ? value.messages : []
   const replayed = messages.reduce<A2UISurface | null>((surface, envelope) => applyA2UIEnvelope(surface, envelope), null)
-  if (replayed?.mindmap) return replayed
+  if (replayed?.mindmap) return title ? { ...replayed, title } : replayed
   const surfaceId = typeof value.surfaceId === "string" ? value.surfaceId : ""
   const mindmap = parseNode(value.mindmap)
-  const title = typeof value.title === "string" ? value.title.trim() : ""
   return surfaceId && value.catalogId === MINDMAP_CATALOG_ID && mindmap
     ? { surfaceId, catalogId: MINDMAP_CATALOG_ID, hasMindmapComponent: true, mindmap, title }
     : null

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -48,7 +48,7 @@ export const messageSchema = z.object({
   delegation: z.record(z.string(), z.unknown()).optional(),
   plan: z.record(z.string(), z.unknown()).nullable().optional(),
   todos: z.array(z.record(z.string(), z.unknown())).optional(),
-  a2ui: z.record(z.string(), z.unknown()).nullable().optional(),
+  a2ui: z.union([z.record(z.string(), z.unknown()), z.array(z.record(z.string(), z.unknown()))]).nullable().optional(),
   context_snapshot: z.record(z.string(), z.unknown()).optional(),
 })
 

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -75,7 +75,7 @@ import {
   useTurn,
 } from "@/lib/queries";
 import { consumeEventStream } from "@/lib/api";
-import { applyA2UIEnvelope, type A2UISurface } from "@/lib/a2ui";
+import { applyA2UIEnvelope, applyA2UISurfaceMetadata, type A2UISurface } from "@/lib/a2ui";
 import { formatEvidenceCitations } from "@/lib/evidence";
 import { summarizeRunActivity } from "@/lib/run-activity";
 import { agentEventSchema, turnResultSchema } from "@/lib/schemas";
@@ -140,7 +140,9 @@ function MessageBubble({
             <p className="whitespace-pre-wrap">{message.content}</p>
           )}
         </MessageContent>
-        {assistant && <A2UIMindmap surface={message.a2ui} onInspectEvidence={() => onInspect("evidence")} />}
+        {assistant && (Array.isArray(message.a2ui) ? message.a2ui : [message.a2ui]).map((surface, index) => (
+          <A2UIMindmap key={typeof surface?.surfaceId === "string" ? surface.surfaceId : index} surface={surface} onInspectEvidence={() => onInspect("evidence")} />
+        ))}
         {assistant && (evidenceCount > 0 || traceCount > 0 || message.plan) && (
           <div className="mt-2 flex flex-wrap gap-1.5">
             {(evidenceCount > 0 || retrievedEvidenceCount > 0) && (
@@ -312,11 +314,11 @@ function RunActivity({ events }: { events: AgentEvent[] }) {
 type LiveRun = {
   events: AgentEvent[];
   answer: string;
-  surface: A2UISurface | null;
+  surfaces: Record<string, A2UISurface>;
 };
 
 function emptyLiveRun(): LiveRun {
-  return { events: [], answer: "", surface: null };
+  return { events: [], answer: "", surfaces: {} };
 }
 
 function ResearchWorkspace({
@@ -372,13 +374,22 @@ function ResearchWorkspace({
           },
         };
       if (event.eventType === "ui.a2ui")
-        return {
-          ...current,
-          [event.runId]: {
-            ...run,
-            surface: applyA2UIEnvelope(run.surface, event.payload.envelope),
-          },
-        };
+        {
+          const surfaceMetadata = event.payload.surface && typeof event.payload.surface === "object"
+            ? event.payload.surface as Record<string, unknown>
+            : null;
+          const previousSurfaceId = typeof surfaceMetadata?.surfaceId === "string"
+            ? surfaceMetadata.surfaceId
+            : "";
+          const nextSurface = applyA2UISurfaceMetadata(
+            applyA2UIEnvelope(run.surfaces[previousSurfaceId] ?? null, event.payload.envelope),
+            surfaceMetadata,
+          );
+          const surfaces = { ...run.surfaces };
+          if (nextSurface) surfaces[nextSurface.surfaceId] = nextSurface;
+          else if (previousSurfaceId) delete surfaces[previousSurfaceId];
+          return { ...current, [event.runId]: { ...run, surfaces } };
+        }
       if (run.events.some((item) => item.eventId === event.eventId))
         return current;
       return {
@@ -500,13 +511,12 @@ function ResearchWorkspace({
                       message={{
                         role: "assistant",
                         content: run.answer,
-                        a2ui: run.surface
-                          ? {
-                              catalogId: run.surface.catalogId,
-                              surfaceId: run.surface.surfaceId,
-                              mindmap: run.surface.mindmap,
-                            }
-                          : null,
+                        a2ui: Object.values(run.surfaces).map((surface) => ({
+                          catalogId: surface.catalogId,
+                          surfaceId: surface.surfaceId,
+                          title: surface.title,
+                          mindmap: surface.mindmap,
+                        })),
                       }}
                       onInspect={openInspector}
                     />


### PR DESCRIPTION
## Background

A durable event log existed, but the live UI only held one A2UI surface and replayed envelopes without their presentation title.

## Changes

- Persist validated surface identity and title alongside each A2UI envelope event.
- Replay live surfaces by surface ID, including independent removal.
- Preserve titles after history reload and prepare the chat UI for concurrent catalog surfaces.
- Add event-persistence and renderer regression tests.

## Risk and rollback

The change is additive to the event payload and backward-compatible with existing persisted messages. Revert the single commit to restore the previous live reducer.

## Validation

- uv run --extra dev python -m pytest tests/unit/test_research_run_events.py tests/unit/test_a2ui_mindmap.py tests/unit/test_turn_engine.py -q (19 passed)
- pnpm --dir web test (16 passed)
- pnpm --dir web lint and pnpm --dir web typecheck (passed)