### PR TITLE
fix: allow manual PyPI publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing vX.Y.Z tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
@@ -29,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.18.0
@@ -42,8 +52,10 @@ jobs:
           enable-cache: true
 
       - name: Verify tag matches package version
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${RELEASE_TAG#v}"
           PKG_VERSION=$(uv run python -c "import agent; print(agent.__version__)")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "ERROR: Tag v$TAG_VERSION does not match package version $PKG_VERSION"


### PR DESCRIPTION
## 背景
`publish-version` 使用 GitHub Actions token 创建 tag 时不会触发 tag-push 工作流；而 PyPI workflow 不支持手动补发，导致版本 tag 可存在但无法发布。

## 改动
- 为 PyPI workflow 增加受控 `workflow_dispatch` 与必填 `release_tag`。
- 两个构建 job 检出该 tag，并继续校验 Python/Web 版本与 tag 一致。

## 风险与回滚
仅调整工作流触发与 checkout ref；普通 tag push 行为不变。回滚该 PR 即恢复原行为。

## 验证
- 审阅 workflow diff
- 合入后以现有 `v1.2.0` tag 手动触发，验证完整 PyPI 发布链路。