### PR TITLE
fix: discover unprefixed release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "skip-github-release": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## 背景与问题
Release Please 实际按 paper-sage-vX.Y.Z 查找历史版本，但本仓库发布规范为 X.Y.Z，导致历史版本即使有 tag 仍被视为未发布。

## 改动范围
- elease-please-config.json: 显式关闭 component 前缀。

## 风险与回滚
仅影响 Release Please 的 tag 识别；回滚此提交即可恢复旧行为。

## 验证
- ConvertFrom-Json 解析通过
- git diff --check 通过