### PR TITLE
fix: improve desktop update and chat recovery

### DIFF
--- a/agent/adapters/sqlite/project_repository.py
+++ b/agent/adapters/sqlite/project_repository.py
@@ -4,8 +4,9 @@ import sqlite3
 import uuid as uuid_lib
 from typing import Any
 
-from .document_repository import init_document_table
 from utils.schemas import FileRecord
+
+from .document_repository import init_document_table
 
 
 def _now_str() -> str:

--- a/agent/adapters/sqlite/project_repository.py
+++ b/agent/adapters/sqlite/project_repository.py
@@ -4,6 +4,7 @@ import sqlite3
 import uuid as uuid_lib
 from typing import Any
 
+from .document_repository import init_document_table
 from utils.schemas import FileRecord
 
 
@@ -25,6 +26,11 @@ def _files_table_columns(db_name: str) -> set[str]:
 
 
 def ensure_files_table_columns(db_name: str = "./database.sqlite") -> None:
+    # Project reads can be issued by a queued research run before a document
+    # upload has initialized the library schema.  Establish the owning table
+    # first so an upgraded or partially initialized local database remains
+    # readable.
+    init_document_table(db_name)
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
     cursor.execute("PRAGMA table_info(files)")

--- a/docs/architecture/desktop-application.md
+++ b/docs/architecture/desktop-application.md
@@ -1,6 +1,6 @@
 # Desktop application boundary
 
-PaperSage has one product UI: `web/src/` is the shared Vite/React application for browsers and Electron. Pages, routes, TanStack Query hooks, schemas and the HTTP API must remain platform-neutral.
+PaperSage has one product UI: `web/src/` is the shared Vite/React application for browsers and Electron. Pages, routes, TanStack Query hooks, schemas and the HTTP API must remain platform-neutral. The desktop shell adds a system tray: closing its window keeps the local service available, while the tray menu's explicit quit action closes the application.
 
 Electron is intentionally limited to `web/electron/`:
 
@@ -12,7 +12,7 @@ Electron is intentionally limited to `web/electron/`:
 
 In Electron, the app shell owns the viewport: the document itself never scrolls, while the central content region provides the single application scroller. Native overflow inside sheets and code blocks uses the same thin themed scrollbar; persistent navigation panes continue to use Radix `ScrollArea`.
 
-Packaged desktop clients use `electron-updater` with the public GitHub Release provider. The updater reads Builder-generated `latest.yml` metadata, prompts before downloading, and asks before restart/install. NSIS on Windows and AppImage on Linux are supported; DEB is intentionally updated by the operating system package manager. macOS auto-update additionally requires a signed release; release CI emits both DMG and ZIP because the ZIP is required for macOS update metadata.
+Packaged desktop clients use `electron-updater` with the public GitHub Release provider. The updater reads Builder-generated `latest.yml` metadata, prompts before downloading, reports byte and percentage progress globally and in Settings, and asks before restart/install. NSIS on Windows and AppImage on Linux are supported; DEB is intentionally updated by the operating system package manager. Development or portable runs explicitly say that no release update channel is configured - they must never be mislabeled as a software-store installation. macOS auto-update additionally requires a signed release; release CI emits both DMG and ZIP because the ZIP is required for macOS update metadata.
 
 The desktop backend uses local PaddleOCR for document ingestion. PDF pages are rendered with PyMuPDF, images are preserved as pages, and TXT is typeset into pages. Word, Excel, and PowerPoint files are first converted to PDF with an installed Microsoft Office desktop application; LibreOffice is the portable fallback. Models are downloaded on first use into `AGENT_OCR_CACHE_DIR` (or the app cache) rather than embedded in every installer. The runtime selects PP-OCRv6 tiny, small, or medium from the available ONNX Runtime provider, RAM, and CPU capacity; every OCR span retains its page, polygon, and confidence for evidence localization.
 

--- a/docs/architecture/web-application.md
+++ b/docs/architecture/web-application.md
@@ -61,9 +61,12 @@ returns before model execution begins. The background worker records canonical
 events with `eventId`, a monotonic per-Run `sequence`, timestamp, type, and payload.
 The client folds `run.*`, `plan.updated`, `tool.*`, and `agent.*` events into a
 compact execution timeline and exposes the full public trace in the inspector.
+It applies events by per-Run sequence, buffers a short out-of-order arrival, and
+ignores replayed sequences. A live answer is one Assistant message made of
+Markdown, activity, citation, and A2UI parts - never a separate Agent chat room.
 
 While a Run is active, the conversation shows one low-emphasis, collapsible
-**执行轨迹** attached to the Assistant. Its data is projected on the server from
+activity summary inside the Assistant message. Its data is projected on the server from
 actual tool lifecycle hooks: queued/started/completed/failed Runs, `write_todos`
 plan updates, tool names with sanitized inputs and outputs, and task-tool based
 subagent lifecycle. It must not infer model intent from event text, present
@@ -72,8 +75,11 @@ Provider reasoning is rendered only when a provider supplies an explicit,
 user-displayable reasoning part; PaperSage currently does not request or persist
 such parts.
 
-Assistant content is rendered by AI Elements `MessageResponse`, with Streamdown
-support for GFM, code blocks, CJK, and KaTeX math. Machine-readable `<evidence>`
+Assistant content is rendered by AI Elements `MessageResponse`, with Markdown,
+code blocks, CJK, and KaTeX math. PaperSage keeps the durable Run protocol as its
+canonical transport rather than forcing it into an AI SDK provider stream; AI SDK
+and AI Elements own rendering and message-part affordances at the React boundary.
+Machine-readable `<evidence>`
 tags are converted into inline citation controls; raw protocol tags must never be
 shown to users. A turn stores cited
 evidence separately from all retrieved candidates so the inspector can distinguish
@@ -91,8 +97,8 @@ in SQLite independently of the browser connection, so a disconnected client does
 not own task execution. The older synchronous `/turns` endpoint remains only as a
 compatibility API; the React application must use the Run protocol.
 
-The Run stream also carries `answer.delta` events produced from LangGraph's
-`messages` stream mode. The client renders those deltas immediately and replays
+The Run stream also carries `message.part.delta` events produced from LangGraph's
+`messages` stream mode. The client renders those parts immediately and replays
 them from sequence zero when reopening a session with a queued or running Run.
 The final `run.completed` event remains the authoritative persisted answer; a
 stream which has begun but cannot provide a final graph state fails rather than

--- a/tests/unit/test_document_library.py
+++ b/tests/unit/test_document_library.py
@@ -56,3 +56,17 @@ def test_upload_project_document_rejects_unsupported_extension(tmp_path: Path) -
         assert "Unsupported" in str(exc)
     else:
         raise AssertionError("unsupported upload was accepted")
+
+
+def test_list_project_files_initializes_missing_document_table(tmp_path: Path) -> None:
+    """A queued turn may run before this legacy database has any documents."""
+    db_name = str(tmp_path / "legacy-projects-only.sqlite")
+    project = create_project(uuid="u1", project_name="Research", db_name=db_name)
+
+    documents = list_project_files(
+        project_uid=str(project["project_uid"]),
+        uuid="u1",
+        db_name=db_name,
+    )
+
+    assert documents == []

--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -1,14 +1,17 @@
-const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron")
+const { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell, Tray } = require("electron")
 const { autoUpdater } = require("electron-updater")
 const { spawn } = require("node:child_process")
 const net = require("node:net")
 const path = require("node:path")
 const fs = require("node:fs")
 const { createUpdateService } = require("./updater.cjs")
+const { createTrayService } = require("./tray.cjs")
 
 const apiPort = Number(process.env.PAPERSAGE_DESKTOP_PORT || 18765)
 let backend
 let logDirectory
+let mainWindow
+let trayService
 
 function getLogDirectory() {
   if (logDirectory) return logDirectory
@@ -120,6 +123,13 @@ async function createWindow() {
     titleBarStyle: "hidden",
     webPreferences: { preload: path.join(__dirname, "preload.cjs"), contextIsolation: true, nodeIntegration: false },
   })
+  mainWindow = window
+  window.on("close", (event) => {
+    if (trayService && !trayService.isQuitting()) {
+      event.preventDefault()
+      window.hide()
+    }
+  })
   window.webContents.on("console-message", (_event, level, message, line, sourceId) => {
     if (level >= 2) writeDesktopLog("renderer.log", `${sourceId}:${line} | ${message}`)
   })
@@ -130,6 +140,13 @@ async function createWindow() {
   const frontendPort = Number(process.env.PAPERSAGE_ELECTRON_DEV ? 5173 : apiPort)
   await waitForPort(frontendPort)
   await window.loadURL(`http://127.0.0.1:${frontendPort}`)
+}
+
+function showMainWindow() {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (mainWindow.isMinimized()) mainWindow.restore()
+  mainWindow.show()
+  mainWindow.focus()
 }
 
 ipcMain.handle("window:minimize", (event) => BrowserWindow.fromWebContents(event.sender)?.minimize())
@@ -148,6 +165,14 @@ process.on("uncaughtException", (error) => reportMainError("桌面应用发生�
 process.on("unhandledRejection", (reason) => reportMainError("桌面应用发生未处理异常", reason))
 
 app.whenReady().then(async () => {
+  trayService = createTrayService({
+    Tray,
+    Menu,
+    nativeImage,
+    app,
+    iconPath: path.join(__dirname, "tray-icon.svg"),
+    showWindow: showMainWindow,
+  })
   await createWindow()
   updates.scheduleCheck()
 }).catch((error) => {
@@ -155,5 +180,9 @@ app.whenReady().then(async () => {
   dialog.showErrorBox("PaperSage 无法启动", "应用启动失败。请在安装目录的 logs 文件夹中查看 main.log。")
   app.quit()
 })
-app.on("window-all-closed", () => { if (process.platform !== "darwin") app.quit() })
-app.on("before-quit", () => { if (backend && !backend.killed) backend.kill() })
+app.on("window-all-closed", () => { if (process.platform !== "darwin" && (!trayService || trayService.isQuitting())) app.quit() })
+app.on("activate", showMainWindow)
+app.on("before-quit", () => {
+  trayService?.beginQuit()
+  if (backend && !backend.killed) backend.kill()
+})

--- a/web/electron/tray-icon.svg
+++ b/web/electron/tray-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#0b1020"/>
+  <path d="M7.5 5.25h9.25l7 6.75v14.75H7.5V5.25Z" fill="#2563eb" fill-opacity=".2" stroke="#93c5fd" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M16.75 5.25V12h7" stroke="#93c5fd" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="m10.5 21.25 4.75-4.5 5.25 3" stroke="#dbeafe" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="10.5" cy="21.25" r="1.45" fill="#60a5fa"/>
+  <circle cx="15.25" cy="16.75" r="1.45" fill="#93c5fd"/>
+  <circle cx="20.5" cy="19.75" r="1.45" fill="#eff6ff"/>
+</svg>

--- a/web/electron/tray.cjs
+++ b/web/electron/tray.cjs
@@ -1,0 +1,33 @@
+/**
+ * @typedef {{ createFromPath: (path: string) => { isEmpty: () => boolean, setTemplateImage: (value: boolean) => void } }} NativeImage
+ * @typedef {{ buildFromTemplate: (items: Array<{ label: string, click: () => void }>) => unknown }} ElectronMenu
+ * @typedef {new (icon: unknown) => { setToolTip: (text: string) => void, setContextMenu: (menu: unknown) => void, on: (event: string, listener: () => void) => void }} ElectronTray
+ */
+
+/**
+ * Owns the desktop tray lifecycle and explicit quit intent.
+ * @param {{ Tray: ElectronTray, Menu: ElectronMenu, nativeImage: NativeImage, app: { quit: () => void }, iconPath: string, showWindow: () => void, platform?: NodeJS.Platform }} dependencies
+ * @returns {{ beginQuit: () => void, isQuitting: () => boolean }}
+ */
+function createTrayService({ Tray, Menu, nativeImage, app, iconPath, showWindow, platform = process.platform }) {
+  const icon = nativeImage.createFromPath(iconPath)
+  if (platform === "darwin" && !icon.isEmpty()) icon.setTemplateImage(true)
+
+  let quitting = false
+  const beginQuit = () => { quitting = true }
+  const quit = () => {
+    beginQuit()
+    app.quit()
+  }
+  const tray = new Tray(icon)
+  tray.setToolTip("PaperSage")
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: "显示 PaperSage", click: showWindow },
+    { label: "退出 PaperSage", click: quit },
+  ]))
+  tray.on("click", showWindow)
+
+  return { beginQuit, isQuitting: () => quitting }
+}
+
+module.exports = { createTrayService }

--- a/web/electron/tray.node.cjs
+++ b/web/electron/tray.node.cjs
@@ -1,0 +1,31 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { createTrayService } = require("./tray.cjs")
+
+test("tray restores the window and exits only through its explicit quit action", () => {
+  let showCount = 0
+  let quitCount = 0
+  let menuItems = []
+  let clickListener
+  const service = createTrayService({
+    Tray: class {
+      setToolTip() {}
+      setContextMenu(menu) { menuItems = menu }
+      on(event, listener) { if (event === "click") clickListener = listener }
+    },
+    Menu: { buildFromTemplate: (items) => items },
+    nativeImage: { createFromPath: () => ({ isEmpty: () => false, setTemplateImage: () => undefined }) },
+    app: { quit: () => { quitCount += 1 } },
+    iconPath: "tray-icon.svg",
+    showWindow: () => { showCount += 1 },
+    platform: "win32",
+  })
+
+  clickListener()
+  menuItems[0].click()
+  menuItems[1].click()
+
+  assert.equal(showCount, 2)
+  assert.equal(quitCount, 1)
+  assert.equal(service.isQuitting(), true)
+})

--- a/web/electron/updater.cjs
+++ b/web/electron/updater.cjs
@@ -2,7 +2,7 @@
  * @typedef {{ isPackaged: boolean, getVersion: () => string }} ElectronApp
  * @typedef {{ showMessageBox: (options: object) => Promise<{ response: number }> }} ElectronDialog
  * @typedef {{ checkForUpdates: () => Promise<unknown>, downloadUpdate: () => Promise<unknown>, quitAndInstall: () => void, on: (event: string, listener: (...args: unknown[]) => void) => void, autoDownload: boolean, autoInstallOnAppQuit: boolean }} ElectronUpdater
- * @typedef {{ status: "downloading" | "progress" | "ready" | "failed", version?: string, percent?: number }} UpdateStatus
+ * @typedef {{ status: "downloading" | "progress" | "ready" | "failed", version?: string, percent?: number, transferred?: number, total?: number, bytesPerSecond?: number }} UpdateStatus
  */
 
 /**
@@ -16,9 +16,16 @@ function supportsAutomaticUpdates({ isPackaged, platform, appImage }) {
   return isPackaged && (platform === "win32" || platform === "darwin" || (platform === "linux" && Boolean(appImage)))
 }
 
+/** @param {{ isPackaged: boolean, platform: NodeJS.Platform, appImage?: string }} runtime */
+function unsupportedUpdateReason({ isPackaged, platform, appImage }) {
+  if (!isPackaged) return "development"
+  if (platform === "linux" && !appImage) return "system-managed"
+  return "unavailable"
+}
+
 /**
  * @param {{ app: ElectronApp, autoUpdater: ElectronUpdater, dialog: ElectronDialog, logger?: Pick<Console, "error">, notify?: (status: UpdateStatus) => void, platform?: NodeJS.Platform, appImage?: string }} dependencies
- * @returns {{ checkForUpdates: () => Promise<{ supported: boolean, status: "unsupported" | "up-to-date" | "available" | "failed", version?: string }>, scheduleCheck: () => void }}
+ * @returns {{ checkForUpdates: () => Promise<{ supported: boolean, status: "unsupported" | "up-to-date" | "available" | "failed", version?: string, reason?: "development" | "system-managed" | "unavailable" }>, scheduleCheck: () => void }}
  */
 function createUpdateService({ app, autoUpdater, dialog, logger = console, notify = () => undefined, platform = process.platform, appImage = process.env.APPIMAGE }) {
   const supported = supportsAutomaticUpdates({ isPackaged: app.isPackaged, platform, appImage })
@@ -50,7 +57,13 @@ function createUpdateService({ app, autoUpdater, dialog, logger = console, notif
       const result = await dialog.showMessageBox({ type: "info", title: "发现新版本", message: `PaperSage ${info.version} 已准备好下载。`, detail: "下载期间可以继续使用 PaperSage；完成后会提醒你重启安装。", buttons: ["开始下载", "暂不更新"], defaultId: 0, cancelId: 1 })
       if (result.response === 0) await download(info.version)
     })
-    autoUpdater.on("download-progress", (progress) => notify({ status: "progress", percent: Number(progress.percent || 0) }))
+    autoUpdater.on("download-progress", (progress) => notify({
+      status: "progress",
+      percent: Number(progress.percent || 0),
+      transferred: Number(progress.transferred || 0),
+      total: Number(progress.total || 0),
+      bytesPerSecond: Number(progress.bytesPerSecond || 0),
+    }))
     autoUpdater.on("update-downloaded", async () => {
       notify({ status: "ready" })
       const result = await dialog.showMessageBox({ type: "info", title: "更新已下载完成", message: "现在重启即可使用新版本。", detail: "如果暂不重启，下一次退出 PaperSage 时会自动完成更新。", buttons: ["立即重启", "退出时更新"], defaultId: 0, cancelId: 1 })
@@ -59,7 +72,11 @@ function createUpdateService({ app, autoUpdater, dialog, logger = console, notif
   }
 
   const checkForUpdates = async () => {
-    if (!supported || checking) return { supported, status: "unsupported" }
+    if (!supported || checking) return {
+      supported,
+      status: "unsupported",
+      reason: unsupportedUpdateReason({ isPackaged: app.isPackaged, platform, appImage }),
+    }
     checking = true
     try {
       const result = await autoUpdater.checkForUpdates()
@@ -74,4 +91,4 @@ function createUpdateService({ app, autoUpdater, dialog, logger = console, notif
   return { checkForUpdates, scheduleCheck: () => { if (supported) setTimeout(() => { void checkForUpdates() }, 12_000) } }
 }
 
-module.exports = { createUpdateService, supportsAutomaticUpdates }
+module.exports = { createUpdateService, supportsAutomaticUpdates, unsupportedUpdateReason }

--- a/web/electron/updater.node.cjs
+++ b/web/electron/updater.node.cjs
@@ -1,6 +1,6 @@
 const test = require("node:test")
 const assert = require("node:assert/strict")
-const { createUpdateService, supportsAutomaticUpdates } = require("./updater.cjs")
+const { createUpdateService, supportsAutomaticUpdates, unsupportedUpdateReason } = require("./updater.cjs")
 
 test("automatic updates require a packaged supported target", () => {
   assert.equal(supportsAutomaticUpdates({ isPackaged: false, platform: "win32" }), false)
@@ -8,6 +8,8 @@ test("automatic updates require a packaged supported target", () => {
   assert.equal(supportsAutomaticUpdates({ isPackaged: true, platform: "darwin" }), true)
   assert.equal(supportsAutomaticUpdates({ isPackaged: true, platform: "linux" }), false)
   assert.equal(supportsAutomaticUpdates({ isPackaged: true, platform: "linux", appImage: "/tmp/PaperSage.AppImage" }), true)
+  assert.equal(unsupportedUpdateReason({ isPackaged: false, platform: "win32" }), "development")
+  assert.equal(unsupportedUpdateReason({ isPackaged: true, platform: "linux" }), "system-managed")
 })
 
 test("manual checks return an explicit current or available version result", async () => {
@@ -55,12 +57,12 @@ test("downloads report progress and completion to the renderer", async () => {
   assert.equal(updater.autoInstallOnAppQuit, true)
 
   await listeners["update-available"]({ version: "1.2.0" })
-  listeners["download-progress"]({ percent: 42.4 })
+  listeners["download-progress"]({ percent: 42.4, transferred: 424, total: 1000, bytesPerSecond: 80 })
   await listeners["update-downloaded"]()
 
   assert.deepEqual(statuses, [
     { status: "downloading", version: "1.2.0" },
-    { status: "progress", percent: 42.4 },
+    { status: "progress", percent: 42.4, transferred: 424, total: 1000, bytesPerSecond: 80 },
     { status: "ready" },
   ])
 })

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node --test electron/updater.node.cjs && vitest run",
+    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs && vitest run",
     "typecheck": "tsc -b --pretty false",
     "preview": "vite preview",
     "desktop:dev": "node electron/dev.cjs",

--- a/web/src/components/desktop-update-status.tsx
+++ b/web/src/components/desktop-update-status.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react"
+import { toast } from "sonner"
+
+import { desktopWindowControls } from "@/lib/platform"
+import { useUiStore } from "@/stores/ui-store"
+
+function formatBytes(value?: number): string {
+  if (!value) return ""
+  const units = ["B", "KB", "MB", "GB"]
+  const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1)
+  return `${(value / 1024 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`
+}
+
+export function DesktopUpdateStatusListener(): null {
+  const desktop = desktopWindowControls()
+  const setDesktopUpdate = useUiStore((state) => state.setDesktopUpdate)
+
+  useEffect(() => {
+    if (!desktop) return
+    return desktop.onUpdateStatus((status) => {
+      if (status.status === "downloading") {
+        setDesktopUpdate({ phase: "downloading", version: status.version, percent: 0 })
+        toast.loading("正在下载更新", { id: "desktop-update", description: "下载期间可以继续使用 PaperSage。" })
+        return
+      }
+      if (status.status === "progress") {
+        const percent = Math.round(status.percent ?? 0)
+        const detail = status.total
+          ? `已完成 ${percent}% · ${formatBytes(status.transferred)} / ${formatBytes(status.total)}`
+          : `已完成 ${percent}%`
+        setDesktopUpdate({ phase: "downloading", ...status, percent })
+        toast.loading("正在下载更新", { id: "desktop-update", description: detail })
+        return
+      }
+      if (status.status === "ready") {
+        setDesktopUpdate({ phase: "ready" })
+        toast.success("更新已下载完成", { id: "desktop-update", description: "现在重启，或在下次退出时自动完成更新。" })
+        return
+      }
+      setDesktopUpdate({ phase: "failed" })
+      toast.error("下载未完成", { id: "desktop-update", description: "请检查网络后再试一次。" })
+    })
+  }, [desktop, setDesktopUpdate])
+
+  return null
+}

--- a/web/src/components/research-run-activity.tsx
+++ b/web/src/components/research-run-activity.tsx
@@ -1,33 +1,10 @@
-import { Wrench } from "lucide-react";
-
 import {
   ChainOfThought,
   ChainOfThoughtContent,
   ChainOfThoughtHeader,
   ChainOfThoughtStep,
 } from "@/components/ai-elements/chain-of-thought";
-import {
-  Plan,
-  PlanContent,
-  PlanDescription,
-  PlanHeader,
-  PlanTitle,
-  PlanTrigger,
-} from "@/components/ai-elements/plan";
-import {
-  Task,
-  TaskContent,
-  TaskItem,
-  TaskTrigger,
-} from "@/components/ai-elements/task";
-import {
-  Tool,
-  ToolContent,
-  ToolHeader,
-  ToolInput,
-  ToolOutput,
-} from "@/components/ai-elements/tool";
-import { summarizeRunActivity } from "@/lib/run-activity";
+import { describeRunEvent, summarizeRunActivity } from "@/lib/run-activity";
 import type { AgentEvent } from "@/lib/schemas";
 
 export function ResearchRunActivity({ events }: { events: AgentEvent[] }) {
@@ -35,11 +12,14 @@ export function ResearchRunActivity({ events }: { events: AgentEvent[] }) {
   const activeStep = [...steps]
     .reverse()
     .find((step) => step.status === "active");
+  const latestEvent = events.at(-1);
   const currentLabel = activeStep
     ? activeStep.label
     : steps.length
-      ? "正在整理研究结果"
-      : "正在准备研究";
+      ? "已完成本次资料处理"
+      : latestEvent
+        ? describeRunEvent(latestEvent)
+        : "正在启动";
   const planEvent = [...events]
     .reverse()
     .find((event) => event.eventType === "plan.updated");
@@ -47,11 +27,20 @@ export function ResearchRunActivity({ events }: { events: AgentEvent[] }) {
     ? (planEvent.payload.todos as Record<string, unknown>[])
     : [];
 
+  if (!steps.length && !todos.length) {
+    return (
+      <p className="mb-3 text-sm text-muted-foreground" role="status" aria-live="polite">
+        {currentLabel}
+      </p>
+    );
+  }
+
   return (
-    <div className="ml-11 max-w-[86%] space-y-3 py-1" role="status" aria-live="polite">
-      <ChainOfThought>
+    <div className="mb-3" role="status" aria-live="polite">
+      <ChainOfThought className="space-y-2">
         <ChainOfThoughtHeader>
           {currentLabel}
+          <span className="text-xs text-muted-foreground">{steps.length} 项活动</span>
           {activeStep && (
             <span className="ml-2 inline-block size-1.5 animate-pulse rounded-full bg-current align-middle" />
           )}
@@ -60,53 +49,20 @@ export function ResearchRunActivity({ events }: { events: AgentEvent[] }) {
           {steps.map((step) => (
             <ChainOfThoughtStep
               key={step.eventIds[0]}
-              icon={step.toolName ? Wrench : undefined}
               label={step.label}
               status={step.status === "failed" ? "pending" : step.status === "active" ? "active" : "complete"}
-            >
-              {step.toolName && (
-                <Tool>
-                  <ToolHeader
-                    type="dynamic-tool"
-                    toolName={step.toolName}
-                    state={step.status === "complete" || step.status === "failed" ? "output-available" : "input-available"}
-                  />
-                  <ToolContent>
-                    <ToolInput input={step.event.payload.arguments ?? {}} />
-                    {step.status !== "active" && (
-                      <ToolOutput
-                        output={String(step.event.payload.summary ?? "")}
-                        errorText={step.status === "failed" ? String(step.event.payload.summary ?? "处理失败") : undefined}
-                      />
-                    )}
-                  </ToolContent>
-                </Tool>
-              )}
-            </ChainOfThoughtStep>
+            />
+          ))}
+          {todos.map((todo, index) => (
+            <ChainOfThoughtStep
+              key={String(todo.id ?? index)}
+              label={String(todo.content ?? todo.title ?? todo.id ?? "未命名步骤")}
+              description={String(todo.status ?? "待处理")}
+              status="pending"
+            />
           ))}
         </ChainOfThoughtContent>
       </ChainOfThought>
-      {todos.length > 0 && (
-        <Plan isStreaming>
-          <PlanHeader>
-            <div>
-              <PlanTitle>研究步骤</PlanTitle>
-              <PlanDescription>本次问题正在按这些步骤推进。</PlanDescription>
-            </div>
-            <PlanTrigger />
-          </PlanHeader>
-          <PlanContent>
-            {todos.map((todo, index) => (
-              <Task key={String(todo.id ?? index)}>
-                <TaskTrigger title={String(todo.content ?? todo.title ?? todo.id ?? "未命名步骤")} />
-                <TaskContent>
-                  <TaskItem>{String(todo.status ?? "待处理")}</TaskItem>
-                </TaskContent>
-              </Task>
-            ))}
-          </PlanContent>
-        </Plan>
-      )}
     </div>
   );
 }

--- a/web/src/lib/live-run.test.ts
+++ b/web/src/lib/live-run.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { createLiveRun, reduceLiveRun } from "@/lib/live-run"
+import type { AgentEvent } from "@/lib/schemas"
+
+function event(sequence: number, eventType: string, payload: Record<string, unknown> = {}): AgentEvent {
+  return {
+    version: 1,
+    eventId: `evt-${sequence}`,
+    eventType,
+    sequence,
+    timestamp: "2026-08-09T00:00:00Z",
+    threadId: "session-1",
+    runId: "run-1",
+    traceId: "trace-1",
+    payload,
+  }
+}
+
+describe("reduceLiveRun", () => {
+  it("orders a replayed stream and renders each text delta exactly once", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, event(2, "message.part.delta", { partId: "text-1", text: "世界" }))
+    run = reduceLiveRun(run, event(1, "message.part.delta", { partId: "text-1", text: "你好，" }))
+    run = reduceLiveRun(run, event(2, "message.part.delta", { partId: "text-1", text: "世界" }))
+
+    expect(run.lastSequence).toBe(2)
+    expect(run.parts).toEqual([{ id: "text-1", type: "markdown", text: "你好，世界" }])
+  })
+})

--- a/web/src/lib/live-run.ts
+++ b/web/src/lib/live-run.ts
@@ -1,0 +1,86 @@
+import { applyA2UIEnvelope, applyA2UISurfaceMetadata, type A2UISurface } from "@/lib/a2ui"
+import type { AgentEvent } from "@/lib/schemas"
+
+export type RenderedMessagePart =
+  | { id: string; type: "markdown"; text: string }
+  | { id: string; type: "a2ui"; surfaceId?: string }
+
+export type LiveRun = {
+  events: AgentEvent[]
+  parts: RenderedMessagePart[]
+  surfaces: Record<string, A2UISurface>
+  lastSequence: number
+  pendingBySequence: Record<number, AgentEvent>
+}
+
+export function createLiveRun(): LiveRun {
+  return { events: [], parts: [], surfaces: {}, lastSequence: 0, pendingBySequence: {} }
+}
+
+function applyEvent(run: LiveRun, event: AgentEvent): LiveRun {
+  if (event.eventType === "message.part.delta") {
+    const partId = String(event.payload.partId ?? "text-0")
+    const text = String(event.payload.text ?? "")
+    const existing = run.parts.find((part) => part.id === partId)
+    const parts = existing?.type === "markdown"
+      ? run.parts.map((part) => part.id === partId && part.type === "markdown" ? { ...part, text: part.text + text } : part)
+      : [...run.parts, { id: partId, type: "markdown" as const, text }]
+    return { ...run, parts }
+  }
+  if (event.eventType === "message.part.insert") {
+    const partId = String(event.payload.partId ?? "")
+    const parts = !partId || run.parts.some((part) => part.id === partId)
+      ? run.parts
+      : [...run.parts, { id: partId, type: "a2ui" as const }]
+    return { ...run, parts }
+  }
+  if (event.eventType === "presentation.failed") {
+    const partId = String(event.payload.partId ?? "")
+    return {
+      ...run,
+      parts: run.parts.filter((part) => part.id !== partId),
+      events: [...run.events, event],
+    }
+  }
+  if (event.eventType === "ui.a2ui") {
+    const metadata = event.payload.surface && typeof event.payload.surface === "object"
+      ? event.payload.surface as Record<string, unknown>
+      : null
+    const previousSurfaceId = typeof metadata?.surfaceId === "string" ? metadata.surfaceId : ""
+    const nextSurface = applyA2UISurfaceMetadata(
+      applyA2UIEnvelope(run.surfaces[previousSurfaceId] ?? null, event.payload.envelope),
+      metadata,
+    )
+    const surfaces = { ...run.surfaces }
+    if (nextSurface) surfaces[nextSurface.surfaceId] = nextSurface
+    else if (previousSurfaceId) delete surfaces[previousSurfaceId]
+    const partId = typeof metadata?.partId === "string" ? metadata.partId : ""
+    const parts = partId && nextSurface
+      ? run.parts.map((part) => part.id === partId && part.type === "a2ui" ? { ...part, surfaceId: nextSurface.surfaceId } : part)
+      : run.parts
+    return { ...run, surfaces, parts }
+  }
+  return { ...run, events: [...run.events, event] }
+}
+
+/**
+ * Applies durable Run events in sequence order.  A reconnect may replay
+ * events, and concurrent stream readers may briefly arrive out of order.
+ */
+export function reduceLiveRun(run: LiveRun, event: AgentEvent): LiveRun {
+  if (event.sequence <= run.lastSequence || run.pendingBySequence[event.sequence]) return run
+  const pendingBySequence = { ...run.pendingBySequence, [event.sequence]: event }
+  let next = { ...run, pendingBySequence }
+  while (next.pendingBySequence[next.lastSequence + 1]) {
+    const sequence = next.lastSequence + 1
+    const nextEvent = next.pendingBySequence[sequence]
+    const remaining = { ...next.pendingBySequence }
+    delete remaining[sequence]
+    next = { ...applyEvent(next, nextEvent), lastSequence: sequence, pendingBySequence: remaining }
+  }
+  return next
+}
+
+export function liveAnswer(parts: RenderedMessagePart[]): string {
+  return parts.reduce((answer, part) => part.type === "markdown" ? answer + part.text : answer, "")
+}

--- a/web/src/lib/platform.ts
+++ b/web/src/lib/platform.ts
@@ -2,7 +2,7 @@ export interface DesktopWindowControls {
   minimize: () => Promise<void>
   toggleMaximize: () => Promise<boolean>
   close: () => Promise<void>
-  checkForUpdates: () => Promise<{ supported: boolean; status: "unsupported" | "up-to-date" | "available" | "failed"; version?: string }>
+  checkForUpdates: () => Promise<{ supported: boolean; status: "unsupported" | "up-to-date" | "available" | "failed"; version?: string; reason?: "development" | "system-managed" | "unavailable" }>
   openLogs: () => Promise<string>
   onUpdateStatus: (listener: (status: DesktopUpdateStatus) => void) => () => void
 }
@@ -11,6 +11,9 @@ export interface DesktopUpdateStatus {
   status: "downloading" | "progress" | "ready" | "failed"
   version?: string
   percent?: number
+  transferred?: number
+  total?: number
+  bytesPerSecond?: number
 }
 
 declare global {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 
 import { Toaster } from "@/components/ui/sonner"
+import { DesktopUpdateStatusListener } from "@/components/desktop-update-status"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { router } from "@/router"
 
@@ -21,6 +22,7 @@ createRoot(document.getElementById("app")!).render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <RouterProvider router={router} />
+        <DesktopUpdateStatusListener />
         <Toaster richColors position="bottom-right" />
       </TooltipProvider>
     </QueryClientProvider>

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -8,7 +8,7 @@ import {
   Sparkles,
   User,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { A2UIMindmap } from "@/components/a2ui-mindmap";
@@ -45,9 +45,15 @@ import {
   useResumableRuns,
   useTurn,
 } from "@/lib/queries";
-import { consumeEventStream } from "@/lib/api";
-import { applyA2UIEnvelope, applyA2UISurfaceMetadata, type A2UISurface } from "@/lib/a2ui";
 import { formatEvidenceCitations } from "@/lib/evidence";
+import { consumeEventStream } from "@/lib/api";
+import {
+  createLiveRun,
+  liveAnswer,
+  reduceLiveRun,
+  type LiveRun,
+  type RenderedMessagePart,
+} from "@/lib/live-run";
 import { agentEventSchema, turnResultSchema } from "@/lib/schemas";
 import type { AgentEvent, Message, TurnResult } from "@/lib/schemas";
 import { cn } from "@/lib/utils";
@@ -62,10 +68,6 @@ const ResearchRunActivity = lazy(async () => {
   const module = await import("@/components/research-run-activity");
   return { default: module.ResearchRunActivity };
 });
-
-type RenderedMessagePart =
-  | { id: string; type: "markdown"; text: string }
-  | { id: string; type: "a2ui"; surfaceId?: string };
 
 function assistantParts(message: Message): RenderedMessagePart[] {
   const stored: RenderedMessagePart[] = [];
@@ -92,9 +94,11 @@ function assistantParts(message: Message): RenderedMessagePart[] {
 function MessageBubble({
   message,
   onInspect,
+  activity,
 }: {
   message: Message;
   onInspect: (tab: "evidence" | "activity" | "plan") => void;
+  activity?: ReactNode;
 }) {
   const assistant = message.role === "assistant";
   const evidenceCount = message.evidence?.length ?? 0;
@@ -145,6 +149,7 @@ function MessageBubble({
                 }
               }}
             >
+              {activity}
               {parts.map((part) => {
                 if (part.type === "markdown") {
                   const content = part.text === message.content ? renderedContent : formatEvidenceCitations(part.text, message.evidence);
@@ -228,25 +233,6 @@ function MessageBubble({
   );
 }
 
-type LiveRun = {
-  events: AgentEvent[];
-  parts: RenderedMessagePart[];
-  surfaces: Record<string, A2UISurface>;
-  processedEventIds: string[];
-};
-
-function emptyLiveRun(): LiveRun {
-  return { events: [], parts: [], surfaces: {}, processedEventIds: [] };
-}
-
-function liveAnswer(parts: RenderedMessagePart[]): string {
-  let answer = "";
-  for (const part of parts) {
-    if (part.type === "markdown") answer += part.text;
-  }
-  return answer;
-}
-
 function ResearchWorkspace({
   projectId,
   sessionId,
@@ -278,7 +264,7 @@ function ResearchWorkspace({
   const activeRuns = useMemo(() => Object.entries(liveRuns), [liveRuns]);
   const ensureLiveRun = useCallback((runId: string) => {
     setLiveRuns((current) =>
-      current[runId] ? current : { ...current, [runId]: emptyLiveRun() },
+      current[runId] ? current : { ...current, [runId]: createLiveRun() },
     );
   }, []);
   const discardLiveRun = useCallback((runId: string) => {
@@ -291,72 +277,9 @@ function ResearchWorkspace({
   }, []);
   const handleRunEvent = useCallback((event: AgentEvent) => {
     setLiveRuns((current) => {
-      const run = current[event.runId] ?? emptyLiveRun();
-      if (run.processedEventIds.includes(event.eventId)) return current;
-      const processedEventIds = [...run.processedEventIds, event.eventId];
-      if (event.eventType === "message.part.delta") {
-        const partId = String(event.payload.partId ?? "text-0");
-        const text = String(event.payload.text ?? "");
-        const existing = run.parts.find((part) => part.id === partId);
-        const parts = existing?.type === "markdown"
-          ? run.parts.map((part) => part.id === partId && part.type === "markdown" ? { ...part, text: part.text + text } : part)
-          : [...run.parts, { id: partId, type: "markdown" as const, text }];
-        return {
-          ...current,
-          [event.runId]: {
-            ...run,
-            processedEventIds,
-            parts,
-          },
-        };
-      }
-      if (event.eventType === "message.part.insert") {
-        const partId = String(event.payload.partId ?? "");
-        const parts = !partId || run.parts.some((part) => part.id === partId)
-          ? run.parts
-          : [...run.parts, { id: partId, type: "a2ui" as const }];
-        return { ...current, [event.runId]: { ...run, processedEventIds, parts } };
-      }
-      if (event.eventType === "presentation.failed") {
-        const partId = String(event.payload.partId ?? "");
-        const events = run.events.some((item) => item.eventId === event.eventId)
-          ? run.events
-          : [...run.events, event];
-        return {
-          ...current,
-          [event.runId]: {
-            ...run,
-            processedEventIds,
-            parts: run.parts.filter((part) => part.id !== partId),
-            events,
-          },
-        };
-      }
-      if (event.eventType === "ui.a2ui")
-        {
-          const surfaceMetadata = event.payload.surface && typeof event.payload.surface === "object"
-            ? event.payload.surface as Record<string, unknown>
-            : null;
-          const previousSurfaceId = typeof surfaceMetadata?.surfaceId === "string"
-            ? surfaceMetadata.surfaceId
-            : "";
-          const nextSurface = applyA2UISurfaceMetadata(
-            applyA2UIEnvelope(run.surfaces[previousSurfaceId] ?? null, event.payload.envelope),
-            surfaceMetadata,
-          );
-          const surfaces = { ...run.surfaces };
-          if (nextSurface) surfaces[nextSurface.surfaceId] = nextSurface;
-          else if (previousSurfaceId) delete surfaces[previousSurfaceId];
-          const partId = typeof surfaceMetadata?.partId === "string" ? surfaceMetadata.partId : "";
-          const parts = partId && nextSurface
-            ? run.parts.map((part) => part.id === partId && part.type === "a2ui" ? { ...part, surfaceId: nextSurface.surfaceId } : part)
-            : run.parts;
-          return { ...current, [event.runId]: { ...run, processedEventIds, surfaces, parts } };
-        }
-      return {
-        ...current,
-        [event.runId]: { ...run, processedEventIds, events: [...run.events, event] },
-      };
+      const run = current[event.runId] ?? createLiveRun();
+      const next = reduceLiveRun(run, event);
+      return next === run ? current : { ...current, [event.runId]: next };
     });
   }, []);
   useEffect(() => {
@@ -466,24 +389,24 @@ function ResearchWorkspace({
               )}
               {activeRuns.map(([runId, run]) => (
                 <div key={runId}>
-                  <Suspense fallback={<div className="ml-11 py-1 text-sm text-muted-foreground">正在准备研究…</div>}>
-                    <ResearchRunActivity events={run.events} />
-                  </Suspense>
-                  {run.parts.length > 0 && (
-                    <MessageBubble
-                      message={{
-                        role: "assistant",
-                        content: liveAnswer(run.parts),
-                        parts: run.parts,
-                        a2ui: Object.values(run.surfaces).map((surface) => ({
-                          catalogId: surface.catalogId,
-                          surfaceId: surface.surfaceId,
-                          title: surface.title,
-                          mindmap: surface.mindmap,
-                        })),
-                      }}
-                      onInspect={openInspector}
-                    />
+                  {(run.events.length > 0 || run.parts.length > 0) && (
+                    <Suspense fallback={null}>
+                      <MessageBubble
+                        message={{
+                          role: "assistant",
+                          content: liveAnswer(run.parts),
+                          parts: run.parts,
+                          a2ui: Object.values(run.surfaces).map((surface) => ({
+                            catalogId: surface.catalogId,
+                            surfaceId: surface.surfaceId,
+                            title: surface.title,
+                            mindmap: surface.mindmap,
+                          })),
+                        }}
+                        onInspect={openInspector}
+                        activity={<ResearchRunActivity events={run.events} />}
+                      />
+                    </Suspense>
                   )}
                 </div>
               ))}

--- a/web/src/pages/settings-page.tsx
+++ b/web/src/pages/settings-page.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
 import { api } from "@/lib/api"
 import { desktopWindowControls } from "@/lib/platform"
 import { keys, useDocumentConversion, useSettings } from "@/lib/queries"
@@ -36,22 +37,8 @@ function FieldError({ message }: { message?: string }) {
 
 function DesktopUpdatesCard() {
   const desktop = desktopWindowControls()
+  const desktopUpdate = useUiStore((state) => state.desktopUpdate)
   const [checking, setChecking] = useState(false)
-  useEffect(() => {
-    if (!desktop) return
-    let downloadToast: string | number | undefined
-    return desktop.onUpdateStatus((status) => {
-      if (status.status === "downloading") downloadToast = toast.loading("正在下载更新", { description: "下载期间可以继续使用 PaperSage。" })
-      else if (status.status === "progress" && downloadToast !== undefined) toast.loading("正在下载更新", { id: downloadToast, description: `已完成 ${Math.round(status.percent ?? 0)}%` })
-      else if (status.status === "ready") {
-        if (downloadToast !== undefined) toast.dismiss(downloadToast)
-        toast.success("更新已下载完成", { description: "现在重启，或在下次退出时自动完成更新。" })
-      } else if (status.status === "failed") {
-        if (downloadToast !== undefined) toast.dismiss(downloadToast)
-        toast.error("下载未完成", { description: "请检查网络后再试一次。" })
-      }
-    })
-  }, [desktop])
   if (!desktop) return null
   const checkForUpdates = async (): Promise<void> => {
     setChecking(true)
@@ -59,7 +46,14 @@ function DesktopUpdatesCard() {
       const result = await desktop.checkForUpdates()
       if (result.status === "available") toast.success(`发现新版本 ${result.version ?? ""}`.trim(), { description: "请选择是否开始下载。" })
       else if (result.status === "up-to-date") toast.success("已是最新版本", { description: "暂时不需要更新。" })
-      else if (result.status === "unsupported") toast.message("此安装方式由系统更新", { description: "请通过你的软件商店或包管理器更新。" })
+      else if (result.status === "unsupported") {
+        const description = result.reason === "development"
+          ? "当前是开发或便携运行方式，未接入发布更新。请使用 PaperSage 桌面安装包。"
+          : result.reason === "system-managed"
+            ? "当前 Linux 安装由系统包管理器负责更新。"
+            : "当前安装方式没有可用的自动更新通道。请从原安装来源更新。"
+        toast.message("无法通过应用内更新", { description })
+      }
       else toast.error("暂时无法检查更新", { description: "请确认网络连接后再试一次。" })
     } catch {
       toast.error("暂时无法检查更新", { description: "请稍后再试一次。" })
@@ -67,7 +61,7 @@ function DesktopUpdatesCard() {
       setChecking(false)
     }
   }
-  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><Download className="size-4 text-primary" />应用更新</CardTitle><CardDescription>有新版本时，你可以选择下载；下载完成后再重启即可。</CardDescription></CardHeader><CardContent><Button type="button" variant="outline" onClick={() => void checkForUpdates()} disabled={checking}><Download />{checking ? "正在检查…" : "检查新版本"}</Button></CardContent></Card>
+  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><Download className="size-4 text-primary" />应用更新</CardTitle><CardDescription>有新版本时，你可以选择下载；下载完成后再重启即可。</CardDescription></CardHeader><CardContent className="space-y-4"><Button type="button" variant="outline" onClick={() => void checkForUpdates()} disabled={checking || desktopUpdate.phase === "downloading"}><Download />{checking ? "正在检查…" : desktopUpdate.phase === "downloading" ? "正在下载" : "检查新版本"}</Button>{desktopUpdate.phase === "downloading" && <div className="space-y-2 rounded-lg border border-border/70 bg-muted/30 p-3"><div className="flex items-center justify-between text-sm"><span>正在下载 {desktopUpdate.version ? `v${desktopUpdate.version}` : "更新"}</span><span className="tabular-nums text-muted-foreground">{Math.round(desktopUpdate.percent ?? 0)}%</span></div><Progress value={desktopUpdate.percent ?? 0} /><p className="text-xs text-muted-foreground">下载期间可以继续使用 PaperSage。</p></div>}{desktopUpdate.phase === "ready" && <p className="text-sm text-emerald-600 dark:text-emerald-400">更新已下载完成，重启后即可使用新版本。</p>}{desktopUpdate.phase === "failed" && <p className="text-sm text-destructive">下载未完成，请检查网络后重试。</p>}</CardContent></Card>
 }
 
 function DesktopDiagnosticsCard() {

--- a/web/src/stores/ui-store.test.ts
+++ b/web/src/stores/ui-store.test.ts
@@ -3,11 +3,18 @@ import { afterEach, describe, expect, it } from "vitest"
 import { useUiStore } from "@/stores/ui-store"
 
 describe("ui store", () => {
-  afterEach(() => useUiStore.setState({ currentProjectId: "" }))
+  afterEach(() => useUiStore.setState({ currentProjectId: "", desktopUpdate: { phase: "idle" } }))
 
   it("keeps the active project available while visiting a global page", () => {
     useUiStore.getState().setCurrentProjectId("project-123")
 
     expect(useUiStore.getState().currentProjectId).toBe("project-123")
+  })
+
+  it("retains a desktop download progress update while the active project changes", () => {
+    useUiStore.getState().setDesktopUpdate({ phase: "downloading", percent: 58, transferred: 58, total: 100 })
+    useUiStore.getState().setCurrentProjectId("project-456")
+
+    expect(useUiStore.getState().desktopUpdate).toMatchObject({ phase: "downloading", percent: 58 })
   })
 })

--- a/web/src/stores/ui-store.ts
+++ b/web/src/stores/ui-store.ts
@@ -1,16 +1,28 @@
 import { create } from "zustand"
 
 type InspectorTab = "evidence" | "activity" | "plan" | "context"
+type DesktopUpdatePhase = "idle" | "downloading" | "ready" | "failed"
+
+export interface DesktopUpdateState {
+  phase: DesktopUpdatePhase
+  version?: string
+  percent?: number
+  transferred?: number
+  total?: number
+  bytesPerSecond?: number
+}
 
 interface UiState {
   currentProjectId: string
   mobileNavOpen: boolean
   inspectorOpen: boolean
   inspectorTab: InspectorTab
+  desktopUpdate: DesktopUpdateState
   setMobileNavOpen: (open: boolean) => void
   setCurrentProjectId: (projectId: string) => void
   openInspector: (tab: InspectorTab) => void
   setInspectorOpen: (open: boolean) => void
+  setDesktopUpdate: (update: DesktopUpdateState) => void
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -18,8 +30,10 @@ export const useUiStore = create<UiState>((set) => ({
   mobileNavOpen: false,
   inspectorOpen: false,
   inspectorTab: "evidence",
+  desktopUpdate: { phase: "idle" },
   setMobileNavOpen: (mobileNavOpen) => set({ mobileNavOpen }),
   setCurrentProjectId: (currentProjectId) => set({ currentProjectId }),
   openInspector: (inspectorTab) => set({ inspectorOpen: true, inspectorTab }),
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
+  setDesktopUpdate: (desktopUpdate) => set({ desktopUpdate }),
 }))


### PR DESCRIPTION
## Background
- Desktop users could not see download progress after leaving Settings, and closing the window exited the app instead of keeping it available in the tray.
- A legacy desktop SQLite database without `files` made queued research runs fail before model execution.
- The conversation split live activity from the assistant response and only deduplicated event IDs.

## Changes
- Add global update progress state, precise unsupported-channel guidance, rotating-log access, and a branded system tray with explicit quit.
- Initialize the document table before project-file reads, including old databases.
- Fold durable Run events by sequence, render activity inside the streaming assistant message, and keep detailed trace in the inspector.
- Document the update, log, and conversation protocol boundaries.

## Risk and rollback
- Desktop behavior changes are isolated to Electron main/preload status events and renderer platform state. Reverting commit `60266ac` restores the prior behavior.

## Validation
- `pnpm --dir web lint` (0 errors; 9 pre-existing fast-refresh warnings)
- `pnpm --dir web typecheck`
- `pnpm --dir web test` (18 tests)
- `pnpm --dir web build`
- `uv run --extra dev python -m pytest tests/unit/test_document_library.py tests/unit/test_db_migrations.py -q` (6 tests)