### PR TITLE
fix: grant release workflow PR permissions

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -20,6 +20,7 @@ permissions:
   actions: write
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   tag-and-publish:


### PR DESCRIPTION
## Background
The canonical publication workflow creates the release tag successfully but cannot clear the matching Release Please pending label because its `GITHUB_TOKEN` lacks pull-request write permission.

## Change
Grant `pull-requests: write` to the existing minimal publication workflow permissions.

## Risk and rollback
This only permits the workflow to remove the pending label from the verified merged Release Please PR. Reverting this commit restores the previous permission set.

## Validation
- `git diff --check`