### PR TITLE
fix(desktop): align updater metadata with installer assets

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -91,6 +91,7 @@ jobs:
             }
           }
           pnpm --dir web run ${{ matrix.command }}
+          pnpm --dir web run desktop:verify-update-metadata
           pnpm --dir web run desktop:checksums
         env:
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}

--- a/docs/architecture/desktop-application.md
+++ b/docs/architecture/desktop-application.md
@@ -20,4 +20,4 @@ OCR output is indexed as normal text while the LanceDB chunk metadata preserves 
 
 Desktop diagnostics are written as rotating files. PaperSage first uses `<installation directory>/logs` and falls back to Electron's application log directory if the installation location is not writable; the Settings page opens that folder. `main.log`, `backend.log`, `backend-process.log`, and `renderer.log` separate desktop, API, child-process, and renderer failures without exposing them in the normal product UI.
 
-GitHub Actions uses the same native package commands for tagged releases. It builds Windows, macOS, and Linux artifacts on their respective runners, then attaches the generated packages and update metadata to the GitHub Release.
+GitHub Actions uses the same native package commands for tagged releases. It builds Windows, macOS, and Linux artifacts on their respective runners, verifies that every generated `latest*.yml` references an attached artifact, then publishes the packages and metadata to the GitHub Release. Windows NSIS artifact names are explicitly configured so the installer and `latest.yml` cannot diverge.

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs && vitest run",
+    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs scripts/verify-update-metadata.node.cjs && vitest run",
     "typecheck": "tsc -b --pretty false",
     "preview": "vite preview",
     "desktop:dev": "node electron/dev.cjs",
@@ -26,7 +26,8 @@
     "desktop:package:win": "pnpm run build && pnpm run desktop:backend && electron-builder --win nsis --publish never",
     "desktop:package:mac": "pnpm run build && pnpm run desktop:backend && electron-builder --mac dmg --publish never",
     "desktop:package:linux": "pnpm run build && pnpm run desktop:backend && electron-builder --linux AppImage deb --publish never",
-    "desktop:checksums": "node scripts/write-checksums.cjs"
+    "desktop:checksums": "node scripts/write-checksums.cjs",
+    "desktop:verify-update-metadata": "node scripts/verify-update-metadata.cjs"
   },
   "dependencies": {
     "@ai-sdk/react": "^4.0.40",
@@ -131,6 +132,7 @@
       "maintainer": "PaperSage Contributors <0verL1nk@users.noreply.github.com>"
     },
     "nsis": {
+      "artifactName": "${productName}-Setup-${version}.${ext}",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "include": "build/installer.nsh"

--- a/web/scripts/verify-update-metadata.cjs
+++ b/web/scripts/verify-update-metadata.cjs
@@ -1,0 +1,40 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const METADATA_FILE_PATTERN = /^latest(?:-(?:mac|linux))?\.yml$/;
+
+function artifactPathFromMetadata(metadata) {
+  const match = metadata.match(/^path:\s*["']?([^\r\n"']+)["']?\s*$/m);
+  if (!match) {
+    throw new Error("Updater metadata does not declare a top-level path.");
+  }
+  return match[1].trim();
+}
+
+function verifyUpdateMetadata(releaseDirectory) {
+  const metadataFiles = fs.readdirSync(releaseDirectory)
+    .filter((name) => METADATA_FILE_PATTERN.test(name));
+
+  if (metadataFiles.length === 0) {
+    throw new Error(`No updater metadata found in ${releaseDirectory}.`);
+  }
+
+  for (const metadataFile of metadataFiles) {
+    const metadataPath = path.join(releaseDirectory, metadataFile);
+    const artifactPath = artifactPathFromMetadata(fs.readFileSync(metadataPath, "utf8"));
+    const resolvedArtifact = path.resolve(releaseDirectory, artifactPath);
+    const relativeArtifact = path.relative(releaseDirectory, resolvedArtifact);
+    if (relativeArtifact.startsWith("..") || path.isAbsolute(relativeArtifact)) {
+      throw new Error(`${metadataFile} references an artifact outside the release directory: ${artifactPath}`);
+    }
+    if (!fs.existsSync(resolvedArtifact)) {
+      throw new Error(`${metadataFile} references missing artifact: ${artifactPath}`);
+    }
+  }
+}
+
+if (require.main === module) {
+  verifyUpdateMetadata(path.resolve(__dirname, "..", "release"));
+}
+
+module.exports = { artifactPathFromMetadata, verifyUpdateMetadata };

--- a/web/scripts/verify-update-metadata.node.cjs
+++ b/web/scripts/verify-update-metadata.node.cjs
@@ -1,0 +1,36 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { verifyUpdateMetadata } = require("./verify-update-metadata.cjs");
+
+function withReleaseDirectory(callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "papersage-update-metadata-"));
+  try {
+    callback(directory);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("accepts metadata whose installer is present in the release bundle", () => {
+  withReleaseDirectory((directory) => {
+    fs.writeFileSync(path.join(directory, "latest.yml"), "version: 1.3.2\npath: PaperSage-Setup-1.3.2.exe\n");
+    fs.writeFileSync(path.join(directory, "PaperSage-Setup-1.3.2.exe"), "installer");
+
+    assert.doesNotThrow(() => verifyUpdateMetadata(directory));
+  });
+});
+
+test("rejects metadata whose installer is absent from the release bundle", () => {
+  withReleaseDirectory((directory) => {
+    fs.writeFileSync(path.join(directory, "latest.yml"), "version: 1.3.2\npath: PaperSage-Setup-1.3.2.exe\n");
+
+    assert.throws(
+      () => verifyUpdateMetadata(directory),
+      /latest\.yml references missing artifact: PaperSage-Setup-1\.3\.2\.exe/,
+    );
+  });
+});


### PR DESCRIPTION
## Background
Windows updater metadata referenced a hyphenated installer name while the published NSIS asset used a dotted name, producing a 404 during download.

## Changes
- configure the Windows NSIS artifact name explicitly
- verify every generated updater metadata file references an actual release artifact before upload
- cover matching and missing metadata references
- document the release invariant

## Risk and rollback
The configuration affects only future Windows release artifact names. Revert this commit to return to Builder defaults; the CI guard remains independently useful.

## Validation
- `pnpm --dir web test -- --runInBand`
- `pnpm --dir web lint`
- `pnpm --dir web typecheck`
