### PR TITLE
fix: route desktop updates through R2

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -180,14 +180,26 @@ jobs:
           generate_release_notes: true
           files: release-assets/*
 
-      - name: Publish updater metadata
+      - name: Publish updater assets to Cloudflare R2
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          UPDATE_BUCKET: overlink-papersage-desktop-updates-prod
         run: |
-          gh release upload "${{ github.ref_name }}" `
-            release-assets/latest.yml `
-            release-assets/latest-mac.yml `
-            release-assets/latest-linux.yml `
-            --clobber
+          $metadataFiles = @("latest.yml", "latest-mac.yml", "latest-linux.yml")
+          $updateFiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+          foreach ($metadataFile in $metadataFiles) {
+            $metadataPath = Join-Path "release-assets" $metadataFile
+            $path = (Select-String -LiteralPath $metadataPath -Pattern '^path:\s*["'']?([^"''\r\n]+)' | Select-Object -First 1).Matches.Groups[1].Value.Trim()
+            if (-not $path) { throw "Updater metadata does not declare a path: $metadataFile" }
+            $updateFiles.Add($metadataFile) | Out-Null
+            $updateFiles.Add($path) | Out-Null
+            $blockmapPath = Join-Path "release-assets" "$path.blockmap"
+            if (Test-Path $blockmapPath) { $updateFiles.Add("$path.blockmap") | Out-Null }
+          }
+          foreach ($file in $updateFiles) {
+            $localPath = Join-Path "release-assets" $file
+            if (-not (Test-Path $localPath)) { throw "Missing updater asset: $file" }
+            $cacheControl = if ($file -like "latest*.yml") { "no-store" } else { "public, max-age=31536000, immutable" }
+            pnpm dlx wrangler r2 object put "$env:UPDATE_BUCKET/$file" --file $localPath --remote --cache-control $cacheControl
+          }

--- a/docs/architecture/desktop-update-behavior.md
+++ b/docs/architecture/desktop-update-behavior.md
@@ -1,0 +1,17 @@
+# Desktop update behavior
+
+Packaged Windows, signed macOS, and AppImage clients check for a new version
+after startup. When one is available, PaperSage downloads it in the background
+and continues to display normal UI. After download, the updater verifies the
+asset and installs it when the application next exits normally. This avoids
+starting an NSIS installer while the tray-resident application is still using
+its own files.
+
+An update cannot replace a running desktop executable. Per-machine Windows
+installations may still require a UAC prompt when the user exits.
+
+The update provider is `https://papersage-updates.overlink.top`, backed by the
+dedicated R2 bucket `overlink-papersage-desktop-updates-prod`. The Desktop
+Release workflow uploads only updater metadata, platform update packages, and
+their blockmaps to that bucket. Metadata is `no-store`; versioned packages are
+immutable and use multiple HTTP range requests for differential updates.

--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -58,7 +58,6 @@ function reportMainError(context, error) {
 const updates = createUpdateService({
   app,
   autoUpdater,
-  dialog,
   logger: { error: (message, error) => reportMainError(message, error) },
   notify: (status) => BrowserWindow.getAllWindows().forEach((window) => window.webContents.send("updates:status", status)),
 })

--- a/web/electron/updater.cjs
+++ b/web/electron/updater.cjs
@@ -1,7 +1,6 @@
 /**
  * @typedef {{ isPackaged: boolean, getVersion: () => string }} ElectronApp
- * @typedef {{ showMessageBox: (options: object) => Promise<{ response: number }> }} ElectronDialog
- * @typedef {{ checkForUpdates: () => Promise<unknown>, downloadUpdate: () => Promise<unknown>, quitAndInstall: () => void, on: (event: string, listener: (...args: unknown[]) => void) => void, autoDownload: boolean, autoInstallOnAppQuit: boolean }} ElectronUpdater
+ * @typedef {{ checkForUpdates: () => Promise<unknown>, downloadUpdate: () => Promise<unknown>, on: (event: string, listener: (...args: unknown[]) => void) => void, autoDownload: boolean, autoInstallOnAppQuit: boolean }} ElectronUpdater
  * @typedef {{ status: "downloading" | "progress" | "ready" | "failed", version?: string, percent?: number, transferred?: number, total?: number, bytesPerSecond?: number }} UpdateStatus
  */
 
@@ -24,10 +23,10 @@ function unsupportedUpdateReason({ isPackaged, platform, appImage }) {
 }
 
 /**
- * @param {{ app: ElectronApp, autoUpdater: ElectronUpdater, dialog: ElectronDialog, logger?: Pick<Console, "error">, notify?: (status: UpdateStatus) => void, platform?: NodeJS.Platform, appImage?: string }} dependencies
+ * @param {{ app: ElectronApp, autoUpdater: ElectronUpdater, logger?: Pick<Console, "error">, notify?: (status: UpdateStatus) => void, platform?: NodeJS.Platform, appImage?: string }} dependencies
  * @returns {{ checkForUpdates: () => Promise<{ supported: boolean, status: "unsupported" | "up-to-date" | "available" | "failed", version?: string, reason?: "development" | "system-managed" | "unavailable" }>, scheduleCheck: () => void }}
  */
-function createUpdateService({ app, autoUpdater, dialog, logger = console, notify = () => undefined, platform = process.platform, appImage = process.env.APPIMAGE }) {
+function createUpdateService({ app, autoUpdater, logger = console, notify = () => undefined, platform = process.platform, appImage = process.env.APPIMAGE }) {
   const supported = supportsAutomaticUpdates({ isPackaged: app.isPackaged, platform, appImage })
   let checking = false
   let downloading = false
@@ -53,10 +52,7 @@ function createUpdateService({ app, autoUpdater, dialog, logger = console, notif
       reportError(error)
       if (downloading) notify({ status: "failed" })
     })
-    autoUpdater.on("update-available", async (info) => {
-      const result = await dialog.showMessageBox({ type: "info", title: "发现新版本", message: `PaperSage ${info.version} 已准备好下载。`, detail: "下载期间可以继续使用 PaperSage；完成后会提醒你重启安装。", buttons: ["开始下载", "暂不更新"], defaultId: 0, cancelId: 1 })
-      if (result.response === 0) await download(info.version)
-    })
+    autoUpdater.on("update-available", async (info) => { await download(info.version) })
     autoUpdater.on("download-progress", (progress) => notify({
       status: "progress",
       percent: Number(progress.percent || 0),
@@ -64,10 +60,8 @@ function createUpdateService({ app, autoUpdater, dialog, logger = console, notif
       total: Number(progress.total || 0),
       bytesPerSecond: Number(progress.bytesPerSecond || 0),
     }))
-    autoUpdater.on("update-downloaded", async () => {
+    autoUpdater.on("update-downloaded", () => {
       notify({ status: "ready" })
-      const result = await dialog.showMessageBox({ type: "info", title: "更新已下载完成", message: "现在重启即可使用新版本。", detail: "如果暂不重启，下一次退出 PaperSage 时会自动完成更新。", buttons: ["立即重启", "退出时更新"], defaultId: 0, cancelId: 1 })
-      if (result.response === 0) autoUpdater.quitAndInstall()
     })
   }
 

--- a/web/electron/updater.node.cjs
+++ b/web/electron/updater.node.cjs
@@ -24,7 +24,6 @@ test("manual checks return an explicit current or available version result", asy
   const service = createUpdateService({
     app: { isPackaged: true, getVersion: () => "1.1.8" },
     autoUpdater: updater,
-    dialog: { showMessageBox: async () => ({ response: 1 }) },
     logger: { error: () => undefined },
     platform: "win32",
   })
@@ -34,7 +33,7 @@ test("manual checks return an explicit current or available version result", asy
   assert.deepEqual(await service.checkForUpdates(), { supported: true, status: "up-to-date", version: "1.1.8" })
 })
 
-test("downloads report progress and completion to the renderer", async () => {
+test("downloads silently and schedules installation for the next app exit", async () => {
   const listeners = {}
   const statuses = []
   const updater = {
@@ -48,7 +47,6 @@ test("downloads report progress and completion to the renderer", async () => {
   createUpdateService({
     app: { isPackaged: true, getVersion: () => "1.1.8" },
     autoUpdater: updater,
-    dialog: { showMessageBox: async () => ({ response: 0 }) },
     logger: { error: () => undefined },
     notify: (status) => statuses.push(status),
     platform: "win32",

--- a/web/package.json
+++ b/web/package.json
@@ -105,10 +105,16 @@
     ],
     "publish": [
       {
+        "provider": "generic",
+        "url": "https://papersage-updates.overlink.top",
+        "useMultipleRangeRequest": true
+      },
+      {
         "provider": "github",
         "owner": "0verL1nk",
         "repo": "PaperSage",
-        "releaseType": "release"
+        "releaseType": "release",
+        "publishAutoUpdate": false
       }
     ],
     "win": {

--- a/web/scripts/verify-update-metadata.node.cjs
+++ b/web/scripts/verify-update-metadata.node.cjs
@@ -5,6 +5,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const { verifyUpdateMetadata } = require("./verify-update-metadata.cjs");
+const packageJson = require("../package.json");
 
 function withReleaseDirectory(callback) {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "papersage-update-metadata-"));
@@ -32,5 +33,15 @@ test("rejects metadata whose installer is absent from the release bundle", () =>
       () => verifyUpdateMetadata(directory),
       /latest\.yml references missing artifact: PaperSage-Setup-1\.3\.2\.exe/,
     );
+  });
+});
+
+test("uses the R2 update endpoint with multiple range requests", () => {
+  const [provider] = packageJson.build.publish;
+
+  assert.deepEqual(provider, {
+    provider: "generic",
+    url: "https://papersage-updates.overlink.top",
+    useMultipleRangeRequest: true,
   });
 });

--- a/web/src/components/desktop-update-status.tsx
+++ b/web/src/components/desktop-update-status.tsx
@@ -34,7 +34,7 @@ export function DesktopUpdateStatusListener(): null {
       }
       if (status.status === "ready") {
         setDesktopUpdate({ phase: "ready" })
-        toast.success("更新已下载完成", { id: "desktop-update", description: "现在重启，或在下次退出时自动完成更新。" })
+        toast.success("更新已下载完成", { id: "desktop-update", description: "将在下次退出 PaperSage 时自动安装。" })
         return
       }
       setDesktopUpdate({ phase: "failed" })

--- a/web/src/pages/settings-page.tsx
+++ b/web/src/pages/settings-page.tsx
@@ -44,7 +44,7 @@ function DesktopUpdatesCard() {
     setChecking(true)
     try {
       const result = await desktop.checkForUpdates()
-      if (result.status === "available") toast.success(`发现新版本 ${result.version ?? ""}`.trim(), { description: "请选择是否开始下载。" })
+      if (result.status === "available") toast.success(`发现新版本 ${result.version ?? ""}`.trim(), { description: "已在后台开始下载。" })
       else if (result.status === "up-to-date") toast.success("已是最新版本", { description: "暂时不需要更新。" })
       else if (result.status === "unsupported") {
         const description = result.reason === "development"
@@ -61,7 +61,7 @@ function DesktopUpdatesCard() {
       setChecking(false)
     }
   }
-  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><Download className="size-4 text-primary" />应用更新</CardTitle><CardDescription>有新版本时，你可以选择下载；下载完成后再重启即可。</CardDescription></CardHeader><CardContent className="space-y-4"><Button type="button" variant="outline" onClick={() => void checkForUpdates()} disabled={checking || desktopUpdate.phase === "downloading"}><Download />{checking ? "正在检查…" : desktopUpdate.phase === "downloading" ? "正在下载" : "检查新版本"}</Button>{desktopUpdate.phase === "downloading" && <div className="space-y-2 rounded-lg border border-border/70 bg-muted/30 p-3"><div className="flex items-center justify-between text-sm"><span>正在下载 {desktopUpdate.version ? `v${desktopUpdate.version}` : "更新"}</span><span className="tabular-nums text-muted-foreground">{Math.round(desktopUpdate.percent ?? 0)}%</span></div><Progress value={desktopUpdate.percent ?? 0} /><p className="text-xs text-muted-foreground">下载期间可以继续使用 PaperSage。</p></div>}{desktopUpdate.phase === "ready" && <p className="text-sm text-emerald-600 dark:text-emerald-400">更新已下载完成，重启后即可使用新版本。</p>}{desktopUpdate.phase === "failed" && <p className="text-sm text-destructive">下载未完成，请检查网络后重试。</p>}</CardContent></Card>
+  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><Download className="size-4 text-primary" />应用更新</CardTitle><CardDescription>发现新版本后会在后台下载，并在下次退出应用时自动安装。</CardDescription></CardHeader><CardContent className="space-y-4"><Button type="button" variant="outline" onClick={() => void checkForUpdates()} disabled={checking || desktopUpdate.phase === "downloading"}><Download />{checking ? "正在检查…" : desktopUpdate.phase === "downloading" ? "正在下载" : "检查新版本"}</Button>{desktopUpdate.phase === "downloading" && <div className="space-y-2 rounded-lg border border-border/70 bg-muted/30 p-3"><div className="flex items-center justify-between text-sm"><span>正在下载 {desktopUpdate.version ? `v${desktopUpdate.version}` : "更新"}</span><span className="tabular-nums text-muted-foreground">{Math.round(desktopUpdate.percent ?? 0)}%</span></div><Progress value={desktopUpdate.percent ?? 0} /><p className="text-xs text-muted-foreground">下载期间可以继续使用 PaperSage。</p></div>}{desktopUpdate.phase === "ready" && <p className="text-sm text-emerald-600 dark:text-emerald-400">更新已下载完成，将在下次退出 PaperSage 时自动安装。</p>}{desktopUpdate.phase === "failed" && <p className="text-sm text-destructive">下载未完成，请检查网络后重试。</p>}</CardContent></Card>
 }
 
 function DesktopDiagnosticsCard() {


### PR DESCRIPTION
## Changes
- route packaged desktop update checks to the dedicated R2 endpoint
- publish update metadata, packages, and blockmaps to R2 from the Desktop Release workflow
- download updates silently and install them on the next normal application exit

## Infrastructure
- R2 bucket: `overlink-papersage-desktop-updates-prod`
- update endpoint: `https://papersage-updates.overlink.top`

## Validation
- `node --test web\\scripts\\verify-update-metadata.node.cjs web\\electron\\updater.node.cjs`
- `pnpm --dir web run typecheck`
- YAML parse check for `desktop-release.yml`