### PR TITLE
fix: upload large desktop updates to R2

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -183,7 +183,10 @@ jobs:
       - name: Publish updater assets to Cloudflare R2
         shell: pwsh
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: https://5bf0e92040869b5b56123207a122dc6d.r2.cloudflarestorage.com
           UPDATE_BUCKET: overlink-papersage-desktop-updates-prod
         run: |
           $metadataFiles = @("latest.yml", "latest-mac.yml", "latest-linux.yml")
@@ -201,5 +204,8 @@ jobs:
             $localPath = Join-Path "release-assets" $file
             if (-not (Test-Path $localPath)) { throw "Missing updater asset: $file" }
             $cacheControl = if ($file -like "latest*.yml") { "no-store" } else { "public, max-age=31536000, immutable" }
-            pnpm dlx wrangler r2 object put "$env:UPDATE_BUCKET/$file" --file $localPath --remote --cache-control $cacheControl
+            aws s3 cp $localPath "s3://$env:UPDATE_BUCKET/$file" `
+              --endpoint-url $env:R2_ENDPOINT `
+              --cache-control $cacheControl `
+              --only-show-errors
           }

--- a/docs/architecture/desktop-update-behavior.md
+++ b/docs/architecture/desktop-update-behavior.md
@@ -15,3 +15,8 @@ dedicated R2 bucket `overlink-papersage-desktop-updates-prod`. The Desktop
 Release workflow uploads only updater metadata, platform update packages, and
 their blockmaps to that bucket. Metadata is `no-store`; versioned packages are
 immutable and use multiple HTTP range requests for differential updates.
+
+The release workflow uses R2's S3-compatible multipart API because desktop
+installers exceed Wrangler's 300 MiB single-upload limit. It requires the
+repository secrets `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY`, created with
+object read/write access limited to that update bucket.


### PR DESCRIPTION
Use R2 S3 multipart upload for desktop updater assets larger than Wrangler supports. Validation: workflow YAML parse and git diff check.