### PR TITLE
fix(orm): reconcile drifted agent_run_events schema

### DIFF
--- a/agent/adapters/orm/runtime_schema.py
+++ b/agent/adapters/orm/runtime_schema.py
@@ -18,8 +18,12 @@ RUNTIME_TABLES = frozenset(
         "agent_task_attempts",
         "agent_task_outbox",
         "agent_steering_inputs",
+        "agent_feature_flags",
     }
 )
+
+# Columns legacy databases may predate before the reconciling 20260815_10 step.
+EVENT_COLUMNS = frozenset({"schema_version", "item_uid", "task_uid"})
 
 
 def ensure_runtime_schema(db_name: str = "./database.sqlite") -> None:
@@ -27,8 +31,14 @@ def ensure_runtime_schema(db_name: str = "./database.sqlite") -> None:
     engine = create_engine(db_name)
     try:
         with engine.connect() as connection:
-            if RUNTIME_TABLES.issubset(inspect(connection).get_table_names()):
+            inspector = inspect(connection)
+            if not RUNTIME_TABLES.issubset(inspector.get_table_names()):
+                run_migrations(db_name)
                 return
+            item_columns = {column["name"] for column in inspector.get_columns("agent_run_items")}
+            event_columns = {column["name"] for column in inspector.get_columns("agent_run_events")}
+            drifted = "last_sequence" not in item_columns or not EVENT_COLUMNS.issubset(event_columns)
+            if drifted:
+                run_migrations(db_name)
     finally:
         engine.dispose()
-    run_migrations(db_name)

--- a/alembic/versions/20260815_08_feature_flags.py
+++ b/alembic/versions/20260815_08_feature_flags.py
@@ -1,0 +1,37 @@
+"""Feature flag overrides for cohort-scoped durable runtime enablement."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260815_08"
+down_revision = "20260814_07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    tables = set(sa.inspect(bind).get_table_names())
+    if "agent_feature_flags" not in tables:
+        op.create_table(
+            "agent_feature_flags",
+            sa.Column("flag_name", sa.String(), primary_key=True),
+            sa.Column("scope_type", sa.String(), primary_key=True),
+            sa.Column("scope_id", sa.String(), primary_key=True),
+            sa.Column("enabled", sa.String(), nullable=False, server_default="false"),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+        )
+        op.create_index(
+            "idx_agent_feature_flags_lookup",
+            "agent_feature_flags",
+            ["flag_name", "scope_type", "scope_id"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_agent_feature_flags_lookup", table_name="agent_feature_flags")
+    op.drop_table("agent_feature_flags")

--- a/alembic/versions/20260815_09_run_item_sequences.py
+++ b/alembic/versions/20260815_09_run_item_sequences.py
@@ -1,0 +1,34 @@
+"""Track the source event sequence on each V2 run-item projection."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260815_09"
+down_revision = "20260815_08"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("agent_run_items")}
+    if "last_sequence" not in columns:
+        op.add_column("agent_run_items", sa.Column("last_sequence", sa.Integer(), nullable=False, server_default="0"))
+        bind.execute(
+            sa.text(
+                "UPDATE agent_run_items SET last_sequence = COALESCE(("
+                "SELECT MAX(events.sequence) FROM agent_run_events AS events "
+                "WHERE events.run_uid = agent_run_items.run_uid AND events.item_uid = agent_run_items.item_uid"
+                "), 0)"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("agent_run_items")}
+    if "last_sequence" in columns:
+        op.drop_column("agent_run_items", "last_sequence")

--- a/alembic/versions/20260815_10_reconcile_run_events.py
+++ b/alembic/versions/20260815_10_reconcile_run_events.py
@@ -1,0 +1,32 @@
+"""Reconcile legacy agent_run_events columns predating Alembic ownership."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260815_10"
+down_revision = "20260815_09"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("agent_run_events")}
+    if "schema_version" not in columns:
+        op.add_column(
+            "agent_run_events",
+            sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        )
+    if "item_uid" not in columns:
+        op.add_column("agent_run_events", sa.Column("item_uid", sa.String()))
+    if "task_uid" not in columns:
+        op.add_column("agent_run_events", sa.Column("task_uid", sa.String()))
+
+
+def downgrade() -> None:
+    # No-op: these columns belong to the 20260812_03 baseline shape, so removing
+    # them would corrupt databases that already had them before this repair step.
+    pass

--- a/tests/unit/test_orm_database.py
+++ b/tests/unit/test_orm_database.py
@@ -25,7 +25,7 @@ def test_baseline_migration_records_alembic_revision(tmp_path: Path) -> None:
     with create_engine(database).connect() as connection:
         revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
         tables = inspect(connection).get_table_names()
-    assert revision == "20260814_07"
+    assert revision == "20260815_10"
     assert {
         "agent_runs",
         "research_artifacts",
@@ -39,6 +39,7 @@ def test_baseline_migration_records_alembic_revision(tmp_path: Path) -> None:
         "agent_steering_inputs",
         "context_memory_items",
         "session_context_summaries",
+        "agent_feature_flags",
     }.issubset(tables)
 
 
@@ -68,5 +69,53 @@ def test_migrations_upgrade_an_existing_database_in_place(tmp_path: Path) -> Non
     with create_engine(database).connect() as connection:
         revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
         tables = inspect(connection).get_table_names()
-    assert revision == "20260814_07"
+    assert revision == "20260815_10"
     assert "agent_tasks" in tables
+
+
+def _build_drifted_database(tmp_path: Path) -> str:
+    """Reproduce a database whose events table predates the reconciled column set."""
+    from alembic import command
+    from alembic.config import Config
+
+    database = str(tmp_path / "drifted.sqlite")
+    root = Path(__file__).resolve().parents[2]
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "alembic"))
+    config.set_main_option("sqlalchemy.url", build_database_url(database))
+
+    run_migrations(database)
+    with create_engine(database).connect() as connection:
+        for column in ("schema_version", "item_uid", "task_uid"):
+            connection.exec_driver_sql(f"ALTER TABLE agent_run_events DROP COLUMN {column}")
+        connection.commit()
+    command.stamp(config, "20260814_07")
+    return database
+
+
+def _agent_run_events_columns(database: str) -> set[str]:
+    with create_engine(database).connect() as connection:
+        return {column["name"] for column in inspect(connection).get_columns("agent_run_events")}
+
+
+def test_migrations_reconcile_drifted_run_events_columns(tmp_path: Path) -> None:
+    database = _build_drifted_database(tmp_path)
+
+    run_migrations(database)
+
+    assert _agent_run_events_columns(database) >= {"schema_version", "item_uid", "task_uid"}
+    with create_engine(database).connect() as connection:
+        assert (
+            connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            == "20260815_10"
+        )
+
+
+def test_ensure_runtime_schema_reconciles_drifted_events(tmp_path: Path) -> None:
+    from agent.adapters.orm.runtime_schema import ensure_runtime_schema
+
+    database = _build_drifted_database(tmp_path)
+
+    ensure_runtime_schema(database)
+
+    assert _agent_run_events_columns(database) >= {"schema_version", "item_uid", "task_uid"}


### PR DESCRIPTION
Legacy desktop databases carry agent_run_events tables created before Alembic ownership: schema_version/item_uid/task_uid are missing while alembic_version already sits at head, so every run insert fails with 'no column named schema_version' (500 on POST /runs).

Lands the 20260815_08-10 migration chain (feature flags, run-item sequences, event reconciliation) so the chain stays walkable, and extends ensure_runtime_schema to detect event-column drift for direct repository callers. Adds regression tests that reproduce the drifted shape and verify self-healing.