### PR TITLE
chore(release): drop stale 1.4.3 release-as pin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
-  "release-as": "1.4.3",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "skip-github-release": true,


### PR DESCRIPTION
Removes the release-as: 1.4.3 pin left over from the hand-cut 1.4.3 hotfix. With the pin, release-please keeps proposing release 1.4.3 although tag v1.4.3 exists (degenerate self-compare changelog section, tag collision on merge). Without it the next release correctly bumps to 1.4.4.