### PR TITLE
fix(ci): release train must squash-merge under squash-only settings

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -50,7 +50,7 @@ jobs:
           PR_NUMBER: ${{ steps.release-pr.outputs.number }}
         shell: bash
         run: |
-          gh pr merge "$PR_NUMBER" --merge
+          gh pr merge "$PR_NUMBER" --squash
           merge_sha="$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')"
           echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The repo now enforces squash-only merges (see AGENTS.md 7.1 and #102), so the release train's 'gh pr merge --merge' would fail on the next ready release PR. Switch it to --squash; mergeCommit still yields the squash SHA for publish-version.