### PR TITLE
fix(orm): reconcile legacy event columns before run-item backfill

### DIFF
--- a/alembic/versions/20260815_09_run_item_sequences.py
+++ b/alembic/versions/20260815_09_run_item_sequences.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlalchemy as sa
+from sqlalchemy.engine import Connection
 
 from alembic import op
 
@@ -11,20 +12,43 @@ down_revision = "20260815_08"
 branch_labels = None
 depends_on = None
 
+_BACKFILL = (
+    "UPDATE agent_run_items SET last_sequence = COALESCE(("
+    "SELECT MAX(events.sequence) FROM agent_run_events AS events "
+    "WHERE events.run_uid = agent_run_items.run_uid AND events.item_uid = agent_run_items.item_uid"
+    "), 0)"
+)
+
+
+def _ensure_event_columns(bind: Connection) -> None:
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("agent_run_events")}
+    if "schema_version" not in columns:
+        op.add_column(
+            "agent_run_events",
+            sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        )
+    if "item_uid" not in columns:
+        op.add_column("agent_run_events", sa.Column("item_uid", sa.String()))
+    if "task_uid" not in columns:
+        op.add_column("agent_run_events", sa.Column("task_uid", sa.String()))
+
 
 def upgrade() -> None:
     bind = op.get_bind()
+    # Legacy databases carry agent_run_events tables created before Alembic
+    # ownership, so the backfill below cannot assume the item_uid column exists
+    # yet (migration 10 repeats this check as a defensive safety net).
+    _ensure_event_columns(bind)
     columns = {column["name"] for column in sa.inspect(bind).get_columns("agent_run_items")}
     if "last_sequence" not in columns:
-        op.add_column("agent_run_items", sa.Column("last_sequence", sa.Integer(), nullable=False, server_default="0"))
-        bind.execute(
-            sa.text(
-                "UPDATE agent_run_items SET last_sequence = COALESCE(("
-                "SELECT MAX(events.sequence) FROM agent_run_events AS events "
-                "WHERE events.run_uid = agent_run_items.run_uid AND events.item_uid = agent_run_items.item_uid"
-                "), 0)"
-            )
+        op.add_column(
+            "agent_run_items",
+            sa.Column("last_sequence", sa.Integer(), nullable=False, server_default="0"),
         )
+    # The backfill is idempotent, so it must also run for databases where the
+    # column already exists: the SQLite driver commits DDL before the failing
+    # statement of an earlier attempt, leaving last_sequence behind at 0.
+    bind.execute(sa.text(_BACKFILL))
 
 
 def downgrade() -> None:

--- a/tests/unit/test_orm_database.py
+++ b/tests/unit/test_orm_database.py
@@ -73,7 +73,11 @@ def test_migrations_upgrade_an_existing_database_in_place(tmp_path: Path) -> Non
     assert "agent_tasks" in tables
 
 
-def _build_drifted_database(tmp_path: Path) -> str:
+def _build_drifted_database(
+    tmp_path: Path,
+    stamp: str = "20260814_07",
+    drop_last_sequence: bool = False,
+) -> str:
     """Reproduce a database whose events table predates the reconciled column set."""
     from alembic import command
     from alembic.config import Config
@@ -88,8 +92,12 @@ def _build_drifted_database(tmp_path: Path) -> str:
     with create_engine(database).connect() as connection:
         for column in ("schema_version", "item_uid", "task_uid"):
             connection.exec_driver_sql(f"ALTER TABLE agent_run_events DROP COLUMN {column}")
+        if drop_last_sequence:
+            connection.exec_driver_sql(
+                "ALTER TABLE agent_run_items DROP COLUMN last_sequence"
+            )
         connection.commit()
-    command.stamp(config, "20260814_07")
+    command.stamp(config, stamp)
     return database
 
 
@@ -119,3 +127,92 @@ def test_ensure_runtime_schema_reconciles_drifted_events(tmp_path: Path) -> None
     ensure_runtime_schema(database)
 
     assert _agent_run_events_columns(database) >= {"schema_version", "item_uid", "task_uid"}
+
+
+def test_migrations_heal_legacy_events_before_backfill(tmp_path: Path) -> None:
+    """A legacy database reaching migration 09 must not crash on the backfill join.
+
+    Reproduces the packaged-desktop first launch: the events table predates the
+    reconciled columns and last_sequence has never been added, so the backfill
+    references events.item_uid before migration 10 could add it.
+    """
+    database = _build_drifted_database(tmp_path, stamp="20260815_08", drop_last_sequence=True)
+    with create_engine(database).connect() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys = OFF")
+        connection.exec_driver_sql(
+            "INSERT INTO agent_runs "
+            "(run_uid, project_uid, session_uid, uuid, client_request_id, prompt, status, created_at, updated_at) "
+            "VALUES ('run-1', 'project-1', 'session-1', 'uuid-1', 'cr-1', 'test', 'completed', "
+            "'2026-08-15T00:00:00Z', '2026-08-15T00:00:00Z')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO agent_run_items "
+            "(item_uid, run_uid, item_type, status, payload_json, created_at, updated_at) "
+            "VALUES ('item-1', 'run-1', 'assistant_text', 'completed', '{}', "
+            "'2026-08-15T00:00:00Z', '2026-08-15T00:00:00Z')"
+        )
+        connection.commit()
+
+    run_migrations(database)
+
+    assert _agent_run_events_columns(database) >= {"schema_version", "item_uid", "task_uid"}
+    with create_engine(database).connect() as connection:
+        assert (
+            connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            == "20260815_10"
+        )
+        assert (
+            connection.execute(
+                text("SELECT last_sequence FROM agent_run_items WHERE item_uid = 'item-1'")
+            ).scalar_one()
+            == 0
+        )
+
+
+def test_migration_09_backfills_last_sequence_from_events(tmp_path: Path) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    database = str(tmp_path / "backfill.sqlite")
+    root = Path(__file__).resolve().parents[2]
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "alembic"))
+    config.set_main_option("sqlalchemy.url", build_database_url(database))
+    command.upgrade(config, "20260815_08")
+
+    with create_engine(database).connect() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys = OFF")
+        connection.exec_driver_sql(
+            "INSERT INTO agent_runs "
+            "(run_uid, project_uid, session_uid, uuid, client_request_id, prompt, status, created_at, updated_at) "
+            "VALUES ('run-1', 'project-1', 'session-1', 'uuid-1', 'cr-1', 'test', 'completed', "
+            "'2026-08-15T00:00:00Z', '2026-08-15T00:00:00Z')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO agent_run_items "
+            "(item_uid, run_uid, item_type, status, payload_json, created_at, updated_at) "
+            "VALUES ('item-1', 'run-1', 'assistant_text', 'completed', '{}', "
+            "'2026-08-15T00:00:00Z', '2026-08-15T00:00:00Z')"
+        )
+        for event_uid, sequence, item_uid in (
+            ("evt-1", 3, "item-1"),
+            ("evt-2", 9, "item-1"),
+            ("evt-3", 5, "item-other"),
+        ):
+            connection.exec_driver_sql(
+                "INSERT INTO agent_run_events "
+                "(event_uid, run_uid, sequence, event_type, timestamp, payload_json, schema_version, item_uid) "
+                f"VALUES ('{event_uid}', 'run-1', {sequence}, 'item.completed', "
+                f"'2026-08-15T00:00:00Z', '{{}}', 2, '{item_uid}')"
+            )
+        connection.commit()
+
+    run_migrations(database)
+
+    with create_engine(database).connect() as connection:
+        assert (
+            connection.execute(
+                text("SELECT last_sequence FROM agent_run_items WHERE item_uid = 'item-1'")
+            ).scalar_one()
+            == 9
+        )


### PR DESCRIPTION
## 问题

v1.4.4 首启在漂移库上闪退:迁移 09 的 last_sequence 回填 JOIN 了 `events.item_uid`,但漂移库要到 10 号迁移才补这列——链走不到 10 就死在 09。且 SQLite 驱动在 DDL 前自动提交,失败后残留 last_sequence 列、版本戳停在 08(第二次启动才自愈,回填被跳过)。

## 修复

- 09 升级开头先确保事件表三列(schema_version/item_uid/task_uid)存在,再做回填
- 回填改为无条件执行(幂等重算),覆盖"列已残留但值为 0"的孤儿态
- 10 号迁移保留为兜底
- 回归测试:首启漂移态(旧代码必崩,已验证红→绿)、回填值正确性

## 验证

`pytest tests/unit/test_orm_database.py` → 8 passed;用户实际桌面库副本模拟,漂移态一次走通至 20260815_10