### PR TITLE
fix(desktop): bundle agent skills and tolerate reasoning-wrapped JSON

### DIFF
--- a/agent/application/session_titles.py
+++ b/agent/application/session_titles.py
@@ -12,7 +12,7 @@ from ..adapters.user_settings import (
     read_base_url_for_user,
     read_model_name_for_user,
 )
-from ..llm_provider import build_openai_compatible_chat_model
+from ..llm_provider import build_openai_compatible_chat_model, invoke_structured_model
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +63,15 @@ def generate_session_title(*, user_uuid: str, project_uid: str, session_uid: str
             base_url=read_base_url_for_user(uuid=user_uuid),
             temperature=0.0,
         )
-        result = model.with_structured_output(SessionTitle).invoke([
-            {"role": "system", "content": _SYSTEM_PROMPT},
-            {"role": "user", "content": f"用户问题：{prompt}\n\n助手回答：{answer}"},
-        ])
-        title = result.title if isinstance(result, SessionTitle) else SessionTitle.model_validate(result).title
+        result = invoke_structured_model(
+            model,
+            SessionTitle,
+            [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": f"用户问题：{prompt}\n\n助手回答：{answer}"},
+            ],
+        )
+        title = result.title
         normalized_title = title.strip()
         if normalized_title:
             update_project_session(session_uid=session_uid, project_uid=project_uid, uuid=user_uuid, session_name=normalized_title, db_name=db_name)

--- a/agent/llm_provider.py
+++ b/agent/llm_provider.py
@@ -1,9 +1,48 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
 from urllib.parse import urlsplit
 
 from langchain_openai import ChatOpenAI
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 
 from .settings import load_agent_settings
+
+_REASONING_BLOCK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+_CODE_FENCE_PATTERN = re.compile(r"```[a-zA-Z0-9_-]*\s*(.*?)\s*```", re.DOTALL)
+
+
+def strip_model_reasoning(text: str) -> str:
+    """Drop <think> reasoning blocks and code fences wrapped around JSON.
+
+    OpenAI-compatible providers such as DashScope emit reasoning text before
+    the JSON payload, which otherwise breaks structured-output parsing.
+    """
+    cleaned = _REASONING_BLOCK_PATTERN.sub("", text)
+    if "<think>" in cleaned:
+        cleaned = cleaned.split("<think>", 1)[0]
+    fenced = _CODE_FENCE_PATTERN.search(cleaned)
+    if fenced:
+        cleaned = fenced.group(1)
+    start, end = cleaned.find("{"), cleaned.rfind("}")
+    if start != -1 and end > start:
+        cleaned = cleaned[start : end + 1]
+    return cleaned.strip()
+
+
+def invoke_structured_model(
+    llm: Any,
+    schema: type[BaseModel],
+    messages: list[dict[str, str]],
+) -> BaseModel:
+    """Invoke a chat model and validate its sanitized JSON against ``schema``."""
+    response = llm.invoke(messages)
+    content = getattr(response, "content", response)
+    if not isinstance(content, str):
+        content = json.dumps(content, ensure_ascii=False)
+    return schema.model_validate_json(strip_model_reasoning(content))
 
 
 def _get_model_max_input_tokens(model_name: str) -> int:

--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .consolidation import MemoryConsolidation, MemoryOperation, process_memory_event
 from .repository import (
     ensure_memory_tables,
@@ -5,7 +7,6 @@ from .repository import (
     touch_memory_items,
     upsert_project_memory_item,
 )
-from .service import search_project_memory_items
 from .store import ensure_memory_layer_ready, query_long_term_memory
 
 __all__ = [
@@ -20,3 +21,13 @@ __all__ = [
     "ensure_memory_layer_ready",
     "query_long_term_memory",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy re-export: agent.memory.service pulls the full adapter stack, which
+    # loops back into this package through utils.utils during module init.
+    if name == "search_project_memory_items":
+        from .service import search_project_memory_items
+
+        return search_project_memory_items
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agent/memory/consolidation.py
+++ b/agent/memory/consolidation.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from ..llm_provider import invoke_structured_model
 from .repository import (
     apply_memory_consolidation,
     claim_memory_event,
@@ -53,7 +54,7 @@ def _build_model_for_user(user_uuid: str):
         read_base_url_for_user,
         read_model_name_for_user,
     )
-    from agent.llm_provider import build_openai_compatible_chat_model
+    from agent.llm_provider import build_openai_compatible_chat_model, invoke_structured_model
 
     api_key = read_api_key_for_user(uuid=user_uuid)
     model_name = read_model_name_for_user(uuid=user_uuid)
@@ -95,16 +96,13 @@ def process_memory_event(event_uid: str, db_name: str = "./database.sqlite") -> 
                 "assistant": event["answer"],
             },
         }
-        result = llm.with_structured_output(MemoryConsolidation).invoke(
+        consolidation = invoke_structured_model(
+            llm,
+            MemoryConsolidation,
             [
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
-            ]
-        )
-        consolidation = (
-            result
-            if isinstance(result, MemoryConsolidation)
-            else MemoryConsolidation.model_validate(result)
+            ],
         )
         apply_memory_consolidation(
             event=event,

--- a/agent/memory/consolidation.py
+++ b/agent/memory/consolidation.py
@@ -54,7 +54,7 @@ def _build_model_for_user(user_uuid: str):
         read_base_url_for_user,
         read_model_name_for_user,
     )
-    from agent.llm_provider import build_openai_compatible_chat_model, invoke_structured_model
+    from agent.llm_provider import build_openai_compatible_chat_model
 
     api_key = read_api_key_for_user(uuid=user_uuid)
     model_name = read_model_name_for_user(uuid=user_uuid)

--- a/agent/memory/store.py
+++ b/agent/memory/store.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .repository import (
     ensure_memory_tables,
@@ -6,6 +6,11 @@ from .repository import (
     touch_memory_items,
     upsert_project_memory_item,
 )
+
+if TYPE_CHECKING:
+    # Import-only for static analysis; the runtime import stays lazy to
+    # break the service -> adapters -> utils -> store import cycle.
+    from .service import search_project_memory_items
 
 __all__ = [
     "ensure_memory_tables",
@@ -38,6 +43,10 @@ def query_long_term_memory(
     limit: int = 5,
     db_name: str = "./database.sqlite",
 ) -> list[dict[str, Any]]:
+    # Module __getattr__ never satisfies bare-name lookups inside functions,
+    # so resolve the facade member lazily here.
+    from .service import search_project_memory_items
+
     return search_project_memory_items(
         uuid=uuid,
         project_uid=project_uid,

--- a/agent/memory/store.py
+++ b/agent/memory/store.py
@@ -6,7 +6,6 @@ from .repository import (
     touch_memory_items,
     upsert_project_memory_item,
 )
-from .service import search_project_memory_items
 
 __all__ = [
     "ensure_memory_tables",
@@ -15,6 +14,16 @@ __all__ = [
     "touch_memory_items",
     "search_project_memory_items",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy re-export: agent.memory.service pulls the full adapter stack, which
+    # loops back here through utils.utils when both initialize at import time.
+    if name == "search_project_memory_items":
+        from .service import search_project_memory_items
+
+        return search_project_memory_items
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def ensure_memory_layer_ready(db_name: str = "./database.sqlite") -> None:

--- a/tests/unit/test_llm_provider_thinking.py
+++ b/tests/unit/test_llm_provider_thinking.py
@@ -1,3 +1,6 @@
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel
+
 from agent import llm_provider as provider
 from agent.settings import AgentSettings
 
@@ -103,3 +106,33 @@ def test_build_model_disables_thinking_when_overridden(monkeypatch):
 
     assert captured["reasoning_effort"] is None
     assert captured["extra_body"] is None
+
+
+class _ReplyModel(BaseModel):
+    title: str
+
+
+class _FakeChatModel:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def invoke(self, _messages):
+        return AIMessage(content=self._content)
+
+
+def test_strip_model_reasoning_removes_wrappers():
+    assert (
+        provider.strip_model_reasoning('<think>x</think>\n\n{"title": "a"}')
+        == '{"title": "a"}'
+    )
+    assert provider.strip_model_reasoning('```json\n{"title": "a"}\n```') == '{"title": "a"}'
+    assert provider.strip_model_reasoning("前言 <think>未闭合的推理") == "前言"
+    assert provider.strip_model_reasoning('{"title": "a"}') == '{"title": "a"}'
+
+
+def test_invoke_structured_model_tolerates_reasoning_prefixes():
+    thinking = _FakeChatModel('<think>The user said hi.</think>\n\n{"title": "问候"}')
+    assert provider.invoke_structured_model(thinking, _ReplyModel, []).title == "问候"
+
+    fenced = _FakeChatModel('```json\n{"title": "围栏"}\n```')
+    assert provider.invoke_structured_model(fenced, _ReplyModel, []).title == "围栏"

--- a/tests/unit/test_memory_consolidation.py
+++ b/tests/unit/test_memory_consolidation.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from agent.memory.consolidation import MemoryConsolidation, MemoryOperation, process_memory_event
+from langchain_core.messages import AIMessage
+
+from agent.memory.consolidation import process_memory_event
 from agent.memory.repository import (
     create_memory_event,
     get_memory_event,
@@ -9,20 +11,17 @@ from agent.memory.repository import (
 
 
 class _StructuredModel:
-    def with_structured_output(self, _schema):
-        return self
-
     def invoke(self, _messages):
-        return MemoryConsolidation(
-            operations=[
-                MemoryOperation(
-                    action="create",
-                    memory_type="procedural",
-                    title="Response preference",
-                    content="The user prefers concise Chinese responses.",
-                    reason="Explicit standing preference",
-                )
-            ]
+        return AIMessage(
+            content=(
+                "<think>The user asked for concise Chinese responses.</think>\n"
+                "```json\n"
+                '{"operations": [{"action": "create", "memory_type": "procedural", '
+                '"title": "Response preference", '
+                '"content": "The user prefers concise Chinese responses.", '
+                '"reason": "Explicit standing preference"}]}\n'
+                "```"
+            )
         )
 
 

--- a/tests/unit/test_session_titles.py
+++ b/tests/unit/test_session_titles.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from langchain_core.messages import AIMessage
+
 from agent.adapters.sqlite.project_repository import (
     create_project,
     create_project_session,
@@ -9,11 +11,10 @@ from agent.application import session_titles
 
 
 class _TitleModel:
-    def with_structured_output(self, _schema):
-        return self
-
     def invoke(self, _messages):
-        return {"title": "比较两种检索策略"}
+        return AIMessage(
+            content='<think>用户想比较检索策略。</think>\n\n{"title": "比较两种检索策略"}'
+        )
 
 
 def test_generate_session_title_names_an_untitled_session(monkeypatch, tmp_path: Path) -> None:

--- a/web/scripts/package-backend.cjs
+++ b/web/scripts/package-backend.cjs
@@ -25,6 +25,7 @@ const args = [
   "--add-data", `${path.join(root, "web", "dist")}${separator}web/dist`,
   "--add-data", `${path.join(root, "alembic.ini")}${separator}.`,
   "--add-data", `${path.join(root, "alembic")}${separator}alembic`,
+  "--add-data", `${path.join(root, "agent", "skills")}${separator}agent/skills`,
   "--collect-data", "paddlex", "--collect-binaries", "paddle",
   path.join(root, "scripts", "desktop_api.py"),
 ]
@@ -34,7 +35,13 @@ if (result.status !== 0) process.exit(result.status ?? 1)
 // The backend runs Alembic migrations at startup; a bundle without the
 // alembic tree bricks the desktop app with "No 'script_location'".
 const internal = path.join(output, "papersage-api", "_internal")
-for (const required of [path.join(internal, "alembic.ini"), path.join(internal, "alembic", "env.py")]) {
+for (const required of [
+  path.join(internal, "alembic.ini"),
+  path.join(internal, "alembic", "env.py"),
+  // The use_skill tool resolves skills next to its loader module; without
+  // the data directory every skill call answers "Available skills: none".
+  path.join(internal, "agent", "skills", "summary", "SKILL.md"),
+]) {
   if (!fs.existsSync(required)) {
     process.stderr.write(`Packaged backend is missing ${required}; migrations would fail at startup.\n`)
     process.exit(1)


### PR DESCRIPTION
## 问题

两个桌面端后台问题(均来自用户日志):

1. **技能全部不可用**:PyInstaller 只收集代码,`agent/skills/` 是数据目录没进包,`use_skill` 只能回答 "Available skills: none"
2. **每轮必炸的结构化解析**:qwen 等 DashScope 兼容模型会在 JSON 前输出 `<think>…</think>` 推理(或代码围栏),openai SDK 的严格结构化解析在第 1 列即失败 → 会话标题生成、记忆整理持续报错

## 修复

- `package-backend.cjs`:`--add-data` 打包 `agent/skills`,打包后校验已知 SKILL.md 落盘(与 alembic 修复同模式)
- `llm_provider` 新增 `strip_model_reasoning` + `invoke_structured_model`:剥离 think 块/围栏/前后散文后再做 pydantic 校验;标题与记忆两条侧链改走该入口(主链路走 tool_calls 不受影响)
- 顺带拆掉一个潜伏的导入环:`agent.memory.__init__ → service → adapters → utils → memory.store → service`,改为 PEP 562 惰性重导出;此前仅靠导入顺序侥幸不炸

## 验证

目标测试 10/10 通过(新增 think 前缀/围栏/未闭合三种用例);全量单测以 CI 为准