### PR TITLE
fix(desktop): keep the launch window visible through backend boot

### DIFF
--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell, Tray } = require("electron")
+const { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, Notification, shell, Tray } = require("electron")
 const { autoUpdater } = require("electron-updater")
 const { spawn } = require("node:child_process")
 const net = require("node:net")
@@ -12,6 +12,14 @@ let backend
 let logDirectory
 let mainWindow
 let trayService
+
+// Updates and long migrations leave a window of seconds where no window
+// exists yet; without the lock a second impatient launch races the first.
+const hasInstanceLock = app.requestSingleInstanceLock()
+if (!hasInstanceLock) {
+  app.quit()
+}
+app.on("second-instance", () => showMainWindow())
 
 function getLogDirectory() {
   if (logDirectory) return logDirectory
@@ -60,17 +68,35 @@ const updates = createUpdateService({
   autoUpdater,
   logger: { error: (message, error) => reportMainError(message, error) },
   notify: (status) => BrowserWindow.getAllWindows().forEach((window) => window.webContents.send("updates:status", status)),
+  notifySystem: () => {
+    if (!Notification.isSupported()) return
+    new Notification({ title: "PaperSage", body: "更新已就绪,正在重启应用,请稍候……" }).show()
+  },
 })
 
-function waitForPort(port, timeoutMs = 30000) {
+function waitForPort(port, timeoutMs = 30000, childProcess) {
   const startedAt = Date.now()
   return new Promise((resolve, reject) => {
+    // A dead backend will never bind the port; surface its exit instead of
+    // letting the user stare at the splash until the timeout.
+    let rejected = false
+    const onExit = (code, signal) => {
+      rejected = true
+      reject(new Error(`PaperSage 服务意外退出：code=${code ?? "-"} signal=${signal ?? "-"}`))
+    }
+    if (childProcess) childProcess.once("exit", onExit)
+    const finish = (action) => {
+      if (childProcess) childProcess.removeListener("exit", onExit)
+      action()
+    }
     const probe = () => {
+      if (rejected) return
       const socket = net.connect({ host: "127.0.0.1", port })
-      socket.once("connect", () => { socket.end(); resolve() })
+      socket.once("connect", () => { socket.end(); finish(resolve) })
       socket.once("error", () => {
         socket.destroy()
-        if (Date.now() - startedAt >= timeoutMs) reject(new Error("PaperSage 服务启动超时"))
+        if (rejected) return
+        if (Date.now() - startedAt >= timeoutMs) finish(() => reject(new Error("PaperSage 服务启动超时")))
         else setTimeout(probe, 250)
       })
     }
@@ -110,7 +136,6 @@ function startBackend() {
 
 async function createWindow() {
   startBackend()
-  await waitForPort(apiPort)
   const window = new BrowserWindow({
     width: 1440,
     height: 920,
@@ -136,6 +161,11 @@ async function createWindow() {
     writeDesktopLog("main.log", `渲染进程异常退出：reason=${details.reason} exitCode=${details.exitCode}`)
   })
   window.once("ready-to-show", () => window.show())
+  // Show the splash before the port wait: post-update launches can spend
+  // tens of seconds in migrations while the backend port stays closed, and
+  // an invisible app invites a second launch.
+  await window.loadFile(path.join(__dirname, "splash.html"))
+  await waitForPort(apiPort, 120_000, backend)
   const frontendPort = Number(process.env.PAPERSAGE_ELECTRON_DEV ? 5173 : apiPort)
   await waitForPort(frontendPort)
   await window.loadURL(`http://127.0.0.1:${frontendPort}`)
@@ -165,23 +195,25 @@ ipcMain.handle("logs:open", async () => shell.openPath(getLogDirectory()))
 process.on("uncaughtException", (error) => reportMainError("桌面应用发生未捕获错误", error))
 process.on("unhandledRejection", (reason) => reportMainError("桌面应用发生未处理异常", reason))
 
-app.whenReady().then(async () => {
-  trayService = createTrayService({
-    Tray,
-    Menu,
-    nativeImage,
-    app,
-    iconPath: path.join(__dirname, "tray-icon.png"),
-    showWindow: showMainWindow,
-    reportError: (message) => writeDesktopLog("main.log", message),
+if (hasInstanceLock) {
+  app.whenReady().then(async () => {
+    trayService = createTrayService({
+      Tray,
+      Menu,
+      nativeImage,
+      app,
+      iconPath: path.join(__dirname, "tray-icon.png"),
+      showWindow: showMainWindow,
+      reportError: (message) => writeDesktopLog("main.log", message),
+    })
+    await createWindow()
+    updates.scheduleCheck()
+  }).catch((error) => {
+    reportMainError("桌面应用无法启动", error)
+    dialog.showErrorBox("PaperSage 无法启动", "应用启动失败。请在安装目录的 logs 文件夹中查看 main.log。")
+    app.quit()
   })
-  await createWindow()
-  updates.scheduleCheck()
-}).catch((error) => {
-  reportMainError("桌面应用无法启动", error)
-  dialog.showErrorBox("PaperSage 无法启动", "应用启动失败。请在安装目录的 logs 文件夹中查看 main.log。")
-  app.quit()
-})
+}
 app.on("window-all-closed", () => { if (process.platform !== "darwin" && (!trayService || trayService.isQuitting())) app.quit() })
 app.on("activate", showMainWindow)
 app.on("before-quit", () => {

--- a/web/electron/splash.html
+++ b/web/electron/splash.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'" />
+  <title>PaperSage</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #09090b;
+      color: #d4d4d8;
+      font-family: -apple-system, "Segoe UI", "Microsoft YaHei", sans-serif;
+      user-select: none;
+      cursor: default;
+    }
+    .stage {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 22px;
+    }
+    .brand {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+    }
+    .brand .name {
+      font-size: 26px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      color: #fafafa;
+    }
+    .brand .mark {
+      font-size: 15px;
+      color: #71717a;
+    }
+    .spinner {
+      width: 26px;
+      height: 26px;
+      border: 3px solid #27272a;
+      border-top-color: #a1a1aa;
+      border-radius: 50%;
+      animation: spin 0.9s linear infinite;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+    .hint {
+      font-size: 13px;
+      color: #71717a;
+      line-height: 1.7;
+      text-align: center;
+      max-width: 420px;
+    }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <div class="brand"><span class="name">PaperSage</span><span class="mark">研究伙伴</span></div>
+    <div class="spinner" role="status" aria-label="正在启动"></div>
+    <p class="hint">正在启动本地服务……<br />首次启动或安装更新后,可能需要一点时间准备数据。</p>
+  </div>
+</body>
+</html>

--- a/web/electron/updater.cjs
+++ b/web/electron/updater.cjs
@@ -23,10 +23,10 @@ function unsupportedUpdateReason({ isPackaged, platform, appImage }) {
 }
 
 /**
- * @param {{ app: ElectronApp, autoUpdater: ElectronUpdater, logger?: Pick<Console, "error">, notify?: (status: UpdateStatus) => void, platform?: NodeJS.Platform, appImage?: string, checkIntervalMs?: number }} dependencies
+ * @param {{ app: ElectronApp, autoUpdater: ElectronUpdater, logger?: Pick<Console, "error">, notify?: (status: UpdateStatus) => void, notifySystem?: () => void, platform?: NodeJS.Platform, appImage?: string, checkIntervalMs?: number }} dependencies
  * @returns {{ checkForUpdates: () => Promise<{ supported: boolean, status: "unsupported" | "up-to-date" | "available" | "failed", version?: string, reason?: "development" | "system-managed" | "unavailable" }>, installUpdate: () => { supported: boolean, status: "unsupported" | "not-ready" | "installing", reason?: "development" | "system-managed" | "unavailable" }, scheduleCheck: () => void }}
  */
-function createUpdateService({ app, autoUpdater, logger = console, notify = () => undefined, platform = process.platform, appImage = process.env.APPIMAGE, checkIntervalMs = 6 * 60 * 60 * 1000 }) {
+function createUpdateService({ app, autoUpdater, logger = console, notify = () => undefined, notifySystem = () => undefined, platform = process.platform, appImage = process.env.APPIMAGE, checkIntervalMs = 6 * 60 * 60 * 1000 }) {
   const supported = supportsAutomaticUpdates({ isPackaged: app.isPackaged, platform, appImage })
   let checking = false
   let downloading = false
@@ -51,7 +51,9 @@ function createUpdateService({ app, autoUpdater, logger = console, notify = () =
     if (!supported) return { supported: false, status: "unsupported", reason: unsupportedUpdateReason({ isPackaged: app.isPackaged, platform, appImage }) }
     if (!readyToInstall) return { supported: true, status: "not-ready" }
     // Silent install plus relaunch: the app comes back on the new version,
-    // so the user never waits in the dark after quitting.
+    // so the user never waits in the dark after quitting. Tell them first —
+    // the window closes immediately and the install gap is otherwise silent.
+    notifySystem()
     autoUpdater.quitAndInstall(true, true)
     return { supported: true, status: "installing" }
   }

--- a/web/electron/updater.node.cjs
+++ b/web/electron/updater.node.cjs
@@ -138,3 +138,29 @@ test("downloads silently and schedules installation for the next app exit", asyn
     { status: "ready" },
   ])
 })
+
+test("installUpdate announces the restart before the window disappears", async () => {
+  const listeners = {}
+  const events = []
+  const updater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    checkForUpdates: async () => ({ updateInfo: { version: "1.2.0" } }),
+    downloadUpdate: async () => undefined,
+    quitAndInstall: () => { events.push("install") },
+    on: (event, listener) => { listeners[event] = listener },
+  }
+  const service = createUpdateService({
+    app: { isPackaged: true, getVersion: () => "1.1.8" },
+    autoUpdater: updater,
+    logger: { error: () => undefined },
+    notifySystem: () => { events.push("notify") },
+    platform: "win32",
+  })
+
+  await listeners["update-available"]({ version: "1.2.0" })
+  await listeners["update-downloaded"]()
+
+  assert.deepEqual(service.installUpdate(), { supported: true, status: "installing" })
+  assert.deepEqual(events, ["notify", "install"])
+})


### PR DESCRIPTION
## 问题

更新后重启(或任何慢启动)期间用户完全无感知,且重复打开会出问题:

- 窗口在 `waitForPort(apiPort)` 之后才创建,而端口要等迁移跑完才绑定 → 更新后的整段迁移时间(可能 30 秒+)没有窗口、没有任务栏图标
- 主进程没有单实例锁 → 用户以为没打开再点一次,拉起第二实例与后端抢端口/文件
- 后端进程若启动即退出,`waitForPort` 仍傻等 30s 超时
- 静默重启安装(quitAndInstall)前无任何提示,窗口瞬间消失

## 修复

- **splash 先行**:窗口立即创建并加载本地 `splash.html`(深色启动页),端口就绪后切换真实界面,启动全程有感知
- **单实例锁**:`requestSingleInstanceLock`,二次启动聚焦现有实例
- **等待智能化**:`waitForPort` 监听后端进程 exit 立刻报错;API 端口超时放宽到 120s(大库迁移)
- **更新前通知**:安装更新静默重启前发系统通知

## 验证

`node --test electron/updater.node.cjs` 7/7(新增"通知先于安装"用例);`node --check` 两个主进程文件;CI 全量