### PR TITLE
fix(web): compact response indicator and null terminal result tolerance

### DIFF
--- a/web/src/components/agent-status.tsx
+++ b/web/src/components/agent-status.tsx
@@ -1,3 +1,4 @@
+import { Loader } from "@/components/ai-elements/loader";
 import { cn } from "@/lib/utils";
 
 export function ThinkingState({ className }: { className?: string }) {
@@ -15,15 +16,9 @@ export function ThinkingState({ className }: { className?: string }) {
 
 export function ResearchOrbs() {
   return (
-    <div className="flex h-14 items-center gap-1.5" aria-label="研究任务正在启动" role="status">
-      {[0, 1, 2].map((index) => (
-        <span
-          className="size-2.5 rounded-full bg-primary/70 motion-safe:animate-bounce"
-          key={index}
-          style={{ animationDelay: `${index * 140}ms` }}
-        />
-      ))}
-      <ThinkingState className="ml-2" />
+    <div className="flex h-6 items-center gap-2" aria-label="研究任务正在启动" role="status">
+      <Loader />
+      <ThinkingState />
     </div>
   );
 }

--- a/web/src/components/ai-elements/loader.tsx
+++ b/web/src/components/ai-elements/loader.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+function Loader({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn("flex items-center gap-1.5", className)}
+      role="status"
+      aria-label="加载中"
+      {...props}
+    >
+      <span className="size-1.5 animate-pulse rounded-full bg-foreground/50" />
+      <span className="size-1.5 animate-pulse rounded-full bg-foreground/50 [animation-delay:150ms]" />
+      <span className="size-1.5 animate-pulse rounded-full bg-foreground/50 [animation-delay:300ms]" />
+    </span>
+  );
+}
+
+export { Loader };

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -164,7 +164,10 @@ export function useTurn(projectId: string, sessionId: string) {
         const event = agentEventSchema.parse(rawEvent)
         onEvent(event)
         if (event.eventType === "run.completed") {
-          result = turnResultSchema.parse(event.payload.result)
+          // Some terminal paths emit a null result; surface it through the
+          // "no final answer" branch instead of a raw ZodError message.
+          const raw = event.payload.result
+          result = raw == null ? undefined : turnResultSchema.parse(raw)
         } else if (event.eventType === "run.failed") {
           failure = String(event.payload.message ?? "Agent 运行失败")
         }


### PR DESCRIPTION
## 问题(用户报告)

1. **loading 图标太大**:等待首个流式片段时,消息气泡里的三颗 10px 弹跳圆点占据 56px 高的行,视觉过重;按约定应使用 ai-elements 的 Loader
2. **反复出现的 Zod 报错**: \`[{"expected":"object","code":"invalid_type",...}]\` —— \`run.completed\` 事件部分终止路径 \`result\` 为 null,前端直接 \`turnResultSchema.parse(null)\` 抛错,原始 ZodError.message 被 toast 出来

## 修复

- 新增 vendored \`ai-elements/loader.tsx\`(三颗 6px 脉冲圆点),替换 ResearchOrbs 的弹跳实现,行高压到 h-6,保留 shimmer 文案
- 终止结果为 null 时回落到既有的"Run 已结束,但没有返回最终结果"提示,不再抛 ZodError

## 验证

CI(vitest + typecheck + Electron shell);无组件级行为断言变化,纯展示与容错