### PR TITLE
fix: structured model JSON schema injection + UTF-8 backend stdio

### DIFF
--- a/agent/llm_provider.py
+++ b/agent/llm_provider.py
@@ -6,7 +6,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from .settings import load_agent_settings
 
@@ -32,17 +32,49 @@ def strip_model_reasoning(text: str) -> str:
     return cleaned.strip()
 
 
+def _coerce_bare_text(schema: type[BaseModel], text: str) -> BaseModel | None:
+    """Rescue single-field schemas when the model answers with the value alone.
+
+    Small OpenAI-compatible models sometimes reply with the bare field value
+    (e.g. just the title) even when asked for JSON.
+    """
+    if "{" in text or not str(text or "").strip():
+        return None
+    field_names = list(schema.model_fields)
+    if len(field_names) != 1:
+        return None
+    try:
+        return schema.model_validate({field_names[0]: text.strip()})
+    except ValidationError:
+        return None
+
+
 def invoke_structured_model(
     llm: Any,
     schema: type[BaseModel],
     messages: list[dict[str, str]],
 ) -> BaseModel:
     """Invoke a chat model and validate its sanitized JSON against ``schema``."""
-    response = llm.invoke(messages)
+    schema_instruction = {
+        "role": "system",
+        "content": (
+            "Respond with exactly one JSON object and no other text. It must "
+            "conform to this JSON schema:\n"
+            f"{json.dumps(schema.model_json_schema(), ensure_ascii=False)}"
+        ),
+    }
+    response = llm.invoke([*messages, schema_instruction])
     content = getattr(response, "content", response)
     if not isinstance(content, str):
         content = json.dumps(content, ensure_ascii=False)
-    return schema.model_validate_json(strip_model_reasoning(content))
+    cleaned = strip_model_reasoning(content)
+    try:
+        return schema.model_validate_json(cleaned)
+    except ValidationError:
+        coerced = _coerce_bare_text(schema, cleaned)
+        if coerced is not None:
+            return coerced
+        raise
 
 
 def _get_model_max_input_tokens(model_name: str) -> int:

--- a/tests/unit/test_llm_provider_thinking.py
+++ b/tests/unit/test_llm_provider_thinking.py
@@ -1,5 +1,6 @@
+import pytest
 from langchain_core.messages import AIMessage
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from agent import llm_provider as provider
 from agent.settings import AgentSettings
@@ -136,3 +137,41 @@ def test_invoke_structured_model_tolerates_reasoning_prefixes():
 
     fenced = _FakeChatModel('```json\n{"title": "围栏"}\n```')
     assert provider.invoke_structured_model(fenced, _ReplyModel, []).title == "围栏"
+
+
+def test_invoke_structured_model_injects_schema_instruction():
+    captured = {}
+
+    class _CapturingModel:
+        def invoke(self, messages):
+            captured["messages"] = messages
+            return AIMessage(content='{"title": "a"}')
+
+    provider.invoke_structured_model(
+        _CapturingModel(),
+        _ReplyModel,
+        [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+        ],
+    )
+
+    assert [message["content"] for message in captured["messages"][:2]] == ["s", "u"]
+    injected = captured["messages"][-1]
+    assert injected["role"] == "system"
+    assert "JSON" in injected["content"]
+    assert '"title"' in injected["content"]
+
+
+def test_invoke_structured_model_coerces_bare_text_for_single_field_schema():
+    plain = _FakeChatModel("思维导图生成技能测试")
+    assert provider.invoke_structured_model(plain, _ReplyModel, []).title == "思维导图生成技能测试"
+
+
+def test_invoke_structured_model_still_raises_for_unrecoverable_output():
+    class _TwoFields(BaseModel):
+        title: str
+        body: str
+
+    with pytest.raises(ValidationError):
+        provider.invoke_structured_model(_FakeChatModel("没有任何花括号的纯文本"), _TwoFields, [])

--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -117,6 +117,9 @@ function startBackend() {
     windowsHide: true,
     env: {
       ...process.env,
+      // Piped stdio on Windows defaults to the ANSI codepage, which garbles
+      // Chinese log lines when decoded as UTF-8 below.
+      PYTHONUTF8: "1",
       APP_LOG_FILE: path.join(getLogDirectory(), "backend.log"),
       APP_LOG_LEVEL: "DEBUG",
       PAPERSAGE_PORT: String(apiPort),


### PR DESCRIPTION
## Summary

- fix(agent): `invoke_structured_model` now injects the pydantic JSON schema into the model invocation and tolerantly coerces bare-text replies for single-field schemas, so session title generation no longer crashes when the model answers with plain text
- fix(desktop): spawn the backend with `PYTHONUTF8=1` so piped stdout/stderr is UTF-8 on Windows; `backend-process.log` Chinese lines were GBK-garbled because Node decoded them as UTF-8

## Test plan

- [x] `tests/unit/test_llm_provider_thinking.py` (3 new cases) pass
- [x] `node --check web/electron/main.cjs`
- [x] Controlled experiment: piped `sys.stdout.encoding` is `gbk` without the env var, `utf-8` with `PYTHONUTF8=1`