### PR TITLE
ci(desktop): build a CUDA Windows package on demand

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      gpu:
+        description: "Build the Windows package with CUDA-accelerated OCR (+1-2 GB)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -14,6 +19,8 @@ jobs:
   native-package:
     name: Build ${{ matrix.name }} package
     runs-on: ${{ matrix.os }}
+    # GPU test builds only produce a Windows artifact; skip the other legs.
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.gpu == true && matrix.name != 'Windows') }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +113,7 @@ jobs:
           pnpm --dir web run desktop:verify-update-metadata
           pnpm --dir web run desktop:checksums
         env:
+          PAPERSAGE_DESKTOP_GPU: ${{ inputs.gpu == true && '1' || '' }}
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}

--- a/web/scripts/package-backend.cjs
+++ b/web/scripts/package-backend.cjs
@@ -20,8 +20,10 @@ function run(command, args, options = {}) {
 }
 
 // The GPU bundle must not ship both onnxruntime and onnxruntime-gpu: they
-// install the same module and whichever wins by path order is undefined.
-// Build PyInstaller from an isolated venv with onnxruntime-gpu instead.
+// install the same importable module and whichever wins by path order is
+// undefined. fastembed declares onnxruntime as a hard dependency, so the
+// pinned closure is installed with --no-deps (it is already fully resolved
+// by uv export) and the CUDA runtime goes in through a separate resolve.
 function resolvePyinstallerInvocation() {
   if (!gpuBundle) {
     return { command: python, prefix: ["run", "--with", "pyinstaller", "pyinstaller"] }
@@ -36,9 +38,16 @@ function resolvePyinstallerInvocation() {
     .readFileSync(requirementsPath, "utf8")
     .split(/\r?\n/)
     .filter((line) => line && !/^onnxruntime==/.test(line.trim()))
-  lines.push("onnxruntime-gpu[cuda,cudnn]>=1.24.3,<2.0.0")
   fs.writeFileSync(requirementsPath, `${lines.join("\n")}\n`)
-  run(python, ["pip", "install", "--python", venvPython, "-r", requirementsPath, "pyinstaller"])
+  run(python, ["pip", "install", "--python", venvPython, "--no-deps", "-r", requirementsPath])
+  run(python, [
+    "pip",
+    "install",
+    "--python",
+    venvPython,
+    "onnxruntime-gpu[cuda,cudnn]>=1.24.3,<2.0.0",
+    "pyinstaller",
+  ])
   return { command: venvPython, prefix: ["-m", "PyInstaller"] }
 }
 


### PR DESCRIPTION
workflow_dispatch gains a gpu flag that runs only the Windows leg with
PAPERSAGE_DESKTOP_GPU=1 and uploads the installer as a run artifact.
The GPU venv installs the pinned closure with --no-deps first: fastembed
declares onnxruntime as a hard dependency, and a normal resolve would
pull the CPU runtime back in next to onnxruntime-gpu.
