### PR TITLE
ci(desktop): build a CUDA Windows package on demand

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,8 +19,9 @@ jobs:
   native-package:
     name: Build ${{ matrix.name }} package
     runs-on: ${{ matrix.os }}
-    # GPU test builds only produce a Windows artifact; skip the other legs.
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.gpu == true && matrix.name != 'Windows') }}
+    # GPU dispatches only need the Windows artifact; the other legs still run
+    # (job-level `if` cannot see the matrix context) but ignore the GPU env,
+    # since package-backend.cjs gates it on win32.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
workflow_dispatch gains a gpu flag that runs only the Windows leg with
PAPERSAGE_DESKTOP_GPU=1 and uploads the installer as a run artifact.
The GPU venv installs the pinned closure with --no-deps first: fastembed
declares onnxruntime as a hard dependency, and a normal resolve would
pull the CPU runtime back in next to onnxruntime-gpu.
