### PR TITLE
feat(web): interleaved message timeline with inline citations

### DIFF
--- a/web/src/components/assistant-run-timeline.tsx
+++ b/web/src/components/assistant-run-timeline.tsx
@@ -1,0 +1,164 @@
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@/components/ai-elements/reasoning";
+import { Tool, ToolHeader } from "@/components/ai-elements/tool";
+import type { LiveRun, RenderedMessagePart } from "@/lib/live-run";
+import { cn } from "@/lib/utils";
+
+export type AssistantTimelineStep =
+  | { kind: "reasoning"; id: string; text: string }
+  | { kind: "tool"; id: string; label: string; status: string; web: boolean }
+  | { kind: "task"; id: string; label: string; status: string };
+
+function isWebTool(name: string): boolean {
+  return /web|search|browser/i.test(name);
+}
+
+function toolState(status: string): "input-available" | "output-available" | "output-error" {
+  if (status === "in_progress") return "input-available";
+  if (status === "failed") return "output-error";
+  return "output-available";
+}
+
+/**
+ * Rebuild the assistant's reasoning/tool chronology from a live run.
+ * `run.events` carries one arrival marker per streamed part plus every item
+ * (tool/task) update in sequence order, so walking it yields the true
+ * interleaving between thinking segments and tool calls.
+ */
+export function buildLiveTimeline(run: LiveRun): AssistantTimelineStep[] {
+  const steps: AssistantTimelineStep[] = [];
+  const byId = new Map<string, AssistantTimelineStep>();
+  const upsert = (step: AssistantTimelineStep): void => {
+    const existing = byId.get(step.id);
+    if (existing) {
+      Object.assign(existing, step);
+      return;
+    }
+    byId.set(step.id, step);
+    steps.push(step);
+  };
+
+  for (const event of run.events) {
+    if (event.version === 2 && event.item) {
+      const item = event.item;
+      const payload = item.payload;
+      if (item.type === "reasoning_summary") {
+        upsert({
+          kind: "reasoning",
+          id: `reasoning:${String(payload.partId ?? item.id)}`,
+          text: "",
+        });
+      } else if (item.type === "tool_call") {
+        const toolName = String(payload.toolName ?? payload.name ?? "工具");
+        upsert({
+          kind: "tool",
+          id: item.id,
+          label: String(payload.summary ?? toolName),
+          status: item.status,
+          web: isWebTool(toolName),
+        });
+      } else if (item.type === "agent_task") {
+        upsert({
+          kind: "task",
+          id: item.id,
+          label: String(payload.task ?? payload.summary ?? "研究子任务"),
+          status: item.status,
+        });
+      }
+    } else if (event.eventType === "message.part.insert" && event.payload.type === "reasoning") {
+      const partId = String(event.payload.partId ?? "");
+      if (partId) upsert({ kind: "reasoning", id: `reasoning:${partId}`, text: "" });
+    }
+  }
+
+  for (const step of steps) {
+    if (step.kind !== "reasoning") continue;
+    const partId = step.id.slice("reasoning:".length);
+    const part = run.parts.find((candidate) => candidate.id === partId);
+    if (part?.type === "reasoning") step.text = part.text;
+  }
+  return steps;
+}
+
+/**
+ * Rebuild the timeline for a stored message: reasoning segments come from the
+ * persisted parts (in order); tool and delegation steps come from the run
+ * trace. The trace carries no reasoning anchors, so reasoning leads.
+ */
+export function buildTraceTimeline(
+  parts: RenderedMessagePart[],
+  trace: Array<Record<string, unknown>>,
+): AssistantTimelineStep[] {
+  const reasoning: AssistantTimelineStep[] = parts
+    .filter((part): part is Extract<RenderedMessagePart, { type: "reasoning" }> => part.type === "reasoning")
+    .map((part) => ({ kind: "reasoning" as const, id: part.id, text: part.text }));
+  const activity: AssistantTimelineStep[] = [];
+  trace.forEach((entry, index) => {
+    const performative = String(entry.performative ?? entry.type ?? "");
+    if (performative === "tool_call" || performative === "skill_activate") {
+      const toolName = String(entry.tool_name ?? entry.toolName ?? entry.name ?? entry.summary ?? "工具调用");
+      activity.push({
+        kind: "tool",
+        id: `trace-${index}`,
+        label: String(entry.summary ?? toolName),
+        status: "completed",
+        web: isWebTool(toolName),
+      });
+    } else if (performative === "delegate_task") {
+      activity.push({
+        kind: "task",
+        id: `trace-${index}`,
+        label: String(entry.task ?? entry.agent ?? entry.summary ?? "研究子任务"),
+        status: "completed",
+      });
+    }
+  });
+  return [...reasoning, ...activity];
+}
+
+export function AssistantTimeline({
+  steps,
+  streaming = false,
+  className,
+}: {
+  steps: AssistantTimelineStep[];
+  streaming?: boolean;
+  className?: string;
+}) {
+  if (!steps.length) return null;
+  const lastIndex = steps.length - 1;
+  return (
+    <div className={cn("mb-3 space-y-2", className)}>
+      {steps.map((step, index) => {
+        if (step.kind === "reasoning") {
+          const streamingNow = streaming && index === lastIndex;
+          return (
+            <Reasoning key={step.id} isStreaming={streamingNow}>
+              <ReasoningTrigger
+                getThinkingMessage={(active, duration) => active
+                  ? "正在思考"
+                  : duration
+                    ? `思考了 ${duration} 秒`
+                    : "思考过程"}
+              />
+              <ReasoningContent>{step.text || (streamingNow ? "…" : "")}</ReasoningContent>
+            </Reasoning>
+          );
+        }
+        return (
+          <Tool key={step.id}>
+            <ToolHeader
+              title={step.label}
+              type="dynamic-tool"
+              state={toolState(step.status)}
+              toolName={step.kind === "task" ? "委派任务" : "工具调用"}
+            />
+          </Tool>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/assistant-run-timeline.tsx
+++ b/web/src/components/assistant-run-timeline.tsx
@@ -60,14 +60,9 @@ export function buildLiveTimeline(run: LiveRun): AssistantTimelineStep[] {
           status: item.status,
           web: isWebTool(toolName),
         });
-      } else if (item.type === "agent_task") {
-        upsert({
-          kind: "task",
-          id: item.id,
-          label: String(payload.task ?? payload.summary ?? "研究子任务"),
-          status: item.status,
-        });
       }
+      // agent_task stays out of the live timeline: the run-activity panel
+      // renders the richer delegation cards while the run is open.
     } else if (event.eventType === "message.part.insert" && event.payload.type === "reasoning") {
       const partId = String(event.payload.partId ?? "");
       if (partId) upsert({ kind: "reasoning", id: `reasoning:${partId}`, text: "" });

--- a/web/src/components/context-composition.tsx
+++ b/web/src/components/context-composition.tsx
@@ -8,7 +8,16 @@ import {
 import type { SessionContextUsage } from "@/lib/context-usage";
 import { cn } from "@/lib/utils";
 
-const SEGMENT_COLORS = ["bg-chart-1", "bg-chart-2", "bg-chart-3", "bg-chart-4", "bg-chart-5"] as const;
+// Validated categorical palette (dataviz method): fixed order, distinct hues,
+// separate steps for dark surfaces; legend labels + segment gaps carry identity
+// where light-mode contrast is below 3:1.
+const SEGMENT_COLORS = [
+  "bg-[#2a78d6] dark:bg-[#3987e5]",
+  "bg-[#eb6834] dark:bg-[#d95926]",
+  "bg-[#1baf7a] dark:bg-[#199e70]",
+  "bg-[#eda100] dark:bg-[#c98500]",
+  "bg-[#e87ba4] dark:bg-[#d55181]",
+] as const;
 
 function segmentPercent(segment: { tokens: number }, maxTokens: number): number {
   if (maxTokens <= 0) return 0;
@@ -23,7 +32,7 @@ export function ContextCompositionCard({ usage }: { usage: SessionContextUsage }
         <ContextContentHeader />
         <ContextContentBody className="space-y-2 text-xs text-muted-foreground">
           <div
-            className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+            className="flex h-2 w-full gap-[2px]"
             role="img"
             aria-label="上下文构成"
           >
@@ -32,8 +41,8 @@ export function ContextCompositionCard({ usage }: { usage: SessionContextUsage }
               if (percent <= 0) return null;
               return (
                 <div
+                  className={cn("h-full flex-none rounded-[3px]", SEGMENT_COLORS[index % SEGMENT_COLORS.length])}
                   key={segment.key}
-                  className={cn("h-full", SEGMENT_COLORS[index % SEGMENT_COLORS.length])}
                   style={{ width: `${percent}%` }}
                 />
               );
@@ -52,7 +61,6 @@ export function ContextCompositionCard({ usage }: { usage: SessionContextUsage }
               </li>
             ))}
           </ul>
-          <p>服务端基于当前会话、系统提示和工具定义计算。</p>
         </ContextContentBody>
       </ContextContent>
     </Context>

--- a/web/src/components/evidence-inline-citations.tsx
+++ b/web/src/components/evidence-inline-citations.tsx
@@ -1,0 +1,65 @@
+import { InlineCitation, InlineCitationSource } from "@/components/ai-elements/inline-citation";
+import { Badge } from "@/components/ui/badge";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import type { ReactNode } from "react";
+import { createContext } from "react";
+
+type EvidenceRecord = Record<string, unknown>;
+
+export const CitationContext = createContext<{ evidence: EvidenceRecord[]; onInspect: () => void }>({
+  evidence: [],
+  onInspect: () => {},
+});
+
+function evidenceSourceLabel(item: EvidenceRecord | undefined, label: string): string {
+  if (!item) return `证据 ${label || "?"}`;
+  return String(item.doc_name ?? item.doc_uid ?? `证据 ${label || "?"}`);
+}
+
+// Stable module-level identity: MessageResponse is memoized on children, so
+// the citation data flows through context instead of these props.
+export const evidenceMarkdownComponents = {
+  a: ({ href, children }: { href?: string; children?: ReactNode }) => {
+    if (!href || !href.startsWith("#evidence-")) {
+      return <a href={href}>{children}</a>;
+    }
+    return (
+      <CitationContext.Consumer>
+        {({ evidence, onInspect }) => {
+          const raw = Array.isArray(children) ? children.join("") : String(children ?? "");
+          const label = raw.replace(/[[\]]/g, "").trim();
+          const index = Number.parseInt(label, 10) - 1;
+          const item = Number.isFinite(index) ? evidence[index] : undefined;
+          const title = evidenceSourceLabel(item, label);
+          const page = item?.page_number ?? item?.page;
+          return (
+            <InlineCitation>
+              <HoverCard closeDelay={100} openDelay={100}>
+                <HoverCardTrigger asChild>
+                  <Badge
+                    className="align-baseline text-xs"
+                    onClick={onInspect}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") onInspect();
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    variant="secondary"
+                  >
+                    {label || "?"}
+                  </Badge>
+                </HoverCardTrigger>
+                <HoverCardContent className="w-72 p-3" side="top">
+                  <InlineCitationSource
+                    title={title}
+                    description={page === undefined || page === null ? undefined : `第 ${page} 页`}
+                  />
+                </HoverCardContent>
+              </HoverCard>
+            </InlineCitation>
+          );
+        }}
+      </CitationContext.Consumer>
+    );
+  },
+};

--- a/web/src/components/research-run-activity.tsx
+++ b/web/src/components/research-run-activity.tsx
@@ -1,10 +1,4 @@
 import {
-  ChainOfThought,
-  ChainOfThoughtContent,
-  ChainOfThoughtHeader,
-  ChainOfThoughtStep,
-} from "@/components/ai-elements/chain-of-thought";
-import {
   Task,
   TaskContent,
   TaskItem,
@@ -28,7 +22,7 @@ import {
   QueueSectionTrigger,
 } from "@/components/ai-elements/queue";
 import type { LiveRunItem } from "@/lib/live-run";
-import { CheckCircle2, CircleDashed, Globe2, LoaderCircle } from "lucide-react";
+import { CheckCircle2, CircleDashed, LoaderCircle } from "lucide-react";
 
 function todoStatusLabel(status: string): string {
   const labels: Record<string, string> = {
@@ -49,15 +43,9 @@ function todoStatusIcon(status: string) {
   return <CircleDashed className="size-4 text-muted-foreground" aria-label="待处理" />;
 }
 
-function isWebSearch(item: LiveRunItem): boolean {
-  const toolName = String(item.payload.toolName ?? item.payload.name ?? "").toLowerCase();
-  return toolName.includes("web") || toolName.includes("search") || toolName.includes("browser");
-}
-
 export function ResearchRunActivity({ items = [] }: { items?: LiveRunItem[] }) {
-  const toolItems = items.filter((item) => item.type === "tool_call");
-  const webSearchItems = toolItems.filter(isWebSearch);
-  const otherToolItems = toolItems.filter((item) => !isWebSearch(item));
+  // Tool calls and reasoning render inside the assistant timeline in message
+  // order; this block keeps only the run-level aggregates.
   const plan = [...items].reverse().find((item) => item.type === "plan");
   const todos = Array.isArray(plan?.payload.todos) ? plan.payload.todos : [];
   const childTasks = items.filter((item) => item.type === "agent_task");
@@ -65,7 +53,7 @@ export function ResearchRunActivity({ items = [] }: { items?: LiveRunItem[] }) {
     (item) => item.type === "human_request" && item.status === "in_progress",
   );
 
-  if (!toolItems.length && !todos.length && !childTasks.length && !queuedInputs.length) {
+  if (!todos.length && !childTasks.length && !queuedInputs.length) {
     return null;
   }
 
@@ -93,40 +81,6 @@ export function ResearchRunActivity({ items = [] }: { items?: LiveRunItem[] }) {
             </QueueSectionContent>
           </QueueSection>
         </Queue>
-      )}
-      {webSearchItems.length > 0 && (
-        <Task className="mb-3" defaultOpen>
-          <TaskTrigger title={`联网检索 · ${webSearchItems.length} 项`} />
-          <TaskContent>
-            {webSearchItems.map((item) => (
-              <TaskItem key={item.id} className="flex items-center gap-2">
-                <Globe2 className={item.status === "in_progress" ? "size-4 animate-pulse text-primary" : "size-4"} />
-                <span>{String(item.payload.summary ?? item.payload.query ?? "正在检索来源")}</span>
-                <span className="ml-auto shrink-0 text-xs">{todoStatusLabel(item.status)}</span>
-              </TaskItem>
-            ))}
-          </TaskContent>
-        </Task>
-      )}
-      {otherToolItems.length > 0 && (
-        <ChainOfThought className="space-y-2">
-          <ChainOfThoughtHeader>
-            正在处理资料
-            <span className="text-xs text-muted-foreground">{otherToolItems.length} 项活动</span>
-            {otherToolItems.some((item) => item.status === "in_progress") && (
-              <span className="ml-2 inline-block size-1.5 animate-pulse rounded-full bg-current align-middle" />
-            )}
-          </ChainOfThoughtHeader>
-          <ChainOfThoughtContent>
-            {otherToolItems.map((item) => (
-              <ChainOfThoughtStep
-                key={item.id}
-                label={String(item.payload.summary ?? item.payload.toolName ?? "工具调用")}
-                status={item.status === "in_progress" ? "active" : item.status === "failed" ? "pending" : "complete"}
-              />
-            ))}
-          </ChainOfThoughtContent>
-        </ChainOfThought>
       )}
       {todos.length > 0 && (
         <Task className="mt-3" defaultOpen={plan?.status === "in_progress"}>

--- a/web/src/lib/live-run.test.ts
+++ b/web/src/lib/live-run.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { buildLiveTimeline } from "@/components/assistant-run-timeline"
 import { createLiveRun, reduceLiveRun } from "@/lib/live-run"
 import type { AgentEvent } from "@/lib/schemas"
 
@@ -27,6 +28,32 @@ function itemEvent(sequence: number, status: string): AgentEvent {
       status,
       taskId: "task-child-1",
       payload: { task: "核验实验结论" },
+    },
+  }
+}
+
+function reasoningItemEvent(sequence: number, partId: string, delta: string): AgentEvent {
+  return {
+    ...event(sequence, "item.delta"),
+    version: 2,
+    item: {
+      id: `item-reasoning-${partId}`,
+      type: "reasoning_summary",
+      status: "in_progress",
+      payload: { partId, delta },
+    },
+  }
+}
+
+function toolEvent(sequence: number, status: string): AgentEvent {
+  return {
+    ...event(sequence, "item.updated"),
+    version: 2,
+    item: {
+      id: "item-tool-1",
+      type: "tool_call",
+      status,
+      payload: { toolName: "search_document", summary: "检索项目资料" },
     },
   }
 }
@@ -93,5 +120,30 @@ describe("reduceLiveRun", () => {
       { id: "text-0", type: "markdown", text: "先核验结论" },
       { id: "reasoning-0", type: "reasoning", text: "证据" },
     ])
+  })
+
+  it("keeps exactly one arrival marker per streamed part", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, textItemEvent(1, "第一"))
+    run = reduceLiveRun(run, textItemEvent(2, "段"))
+    run = reduceLiveRun(run, textItemEvent(3, "更多"))
+
+    expect(run.events).toHaveLength(1)
+    expect(run.events[0]?.sequence).toBe(1)
+  })
+
+  it("interleaves reasoning segments and tool calls in arrival order", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, textItemEvent(1, "先定位", "reasoning_summary"))
+    run = reduceLiveRun(run, toolEvent(2, "in_progress"))
+    run = reduceLiveRun(run, toolEvent(3, "completed"))
+    run = reduceLiveRun(run, reasoningItemEvent(4, "reasoning-1", "再综合"))
+
+    const steps = buildLiveTimeline(run)
+
+    expect(steps.map((step) => step.kind)).toEqual(["reasoning", "tool", "reasoning"])
+    expect(steps[0]).toMatchObject({ id: "reasoning:reasoning-0", text: "先定位" })
+    expect(steps[1]).toMatchObject({ kind: "tool", label: "检索项目资料", status: "completed" })
+    expect(steps[2]).toMatchObject({ id: "reasoning:reasoning-1", text: "再综合" })
   })
 })

--- a/web/src/lib/live-run.ts
+++ b/web/src/lib/live-run.ts
@@ -32,17 +32,20 @@ function applyEvent(run: LiveRun, event: AgentEvent): LiveRun {
     const parts = existing?.type === "markdown" || existing?.type === "reasoning"
       ? run.parts.map((part) => part.id === partId && (part.type === "markdown" || part.type === "reasoning") ? { ...part, text: part.text + text } : part)
       : [...run.parts, { id: partId, type: "markdown" as const, text }]
-    return { ...run, parts }
+    // Keep one arrival marker per part so run.events preserves the chronology
+    // between streamed text and tool/item activity.
+    return { ...run, parts, events: existing ? run.events : [...run.events, event] }
   }
   if (event.eventType === "message.part.insert") {
     const partId = String(event.payload.partId ?? "")
     const partType = event.payload.type === "reasoning" ? "reasoning" : "a2ui"
-    const parts = !partId || run.parts.some((part) => part.id === partId)
+    const known = !partId || run.parts.some((part) => part.id === partId)
+    const parts = known
       ? run.parts
       : partType === "reasoning"
         ? [...run.parts, { id: partId, type: "reasoning" as const, text: "" }]
         : [...run.parts, { id: partId, type: "a2ui" as const }]
-    return { ...run, parts }
+    return { ...run, parts, events: known ? run.events : [...run.events, event] }
   }
   if (event.eventType === "presentation.failed") {
     const partId = String(event.payload.partId ?? "")
@@ -86,7 +89,8 @@ function applyItemEvent(run: LiveRun, event: AgentEvent): LiveRun {
     const parts = existing?.type === type
       ? run.parts.map((part) => part.id === partId && part.type === type ? { ...part, text: delta ? part.text + delta : String(payload.text ?? part.text) } : part)
       : [...run.parts, { id: partId, type, text: delta || String(payload.text ?? "") }]
-    return { ...run, items, parts }
+    // One arrival marker per part keeps run.events a usable chronology log.
+    return { ...run, items, parts, events: existing ? run.events : [...run.events, event] }
   }
   if (item.type === "presentation") {
     const partId = String(payload.partId ?? item.id)

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -21,11 +21,13 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { CitationContext, evidenceMarkdownComponents } from "@/components/evidence-inline-citations";
 import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from "@/components/ai-elements/reasoning";
+  AssistantTimeline,
+  buildLiveTimeline,
+  buildTraceTimeline,
+  type AssistantTimelineStep,
+} from "@/components/assistant-run-timeline";
 import {
   Conversation,
   ConversationContent,
@@ -75,6 +77,13 @@ import type { AgentEvent, Message, TurnResult } from "@/lib/schemas";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/stores/ui-store";
 
+const EXECUTION_MODES = [
+  { value: "auto", label: "自动" },
+  { value: "react", label: "ReAct" },
+  { value: "plan_execute", label: "计划执行" },
+  { value: "agent_teams", label: "团队协作" },
+] as const;
+
 const ResearchInspector = lazy(async () => {
   const module = await import("@/components/research-inspector");
   return { default: module.ResearchInspector };
@@ -115,11 +124,13 @@ function MessageBubble({
   message,
   onInspect,
   activity,
+  timeline,
   isStreaming = false,
 }: {
   message: Message;
   onInspect: (tab: "evidence" | "activity" | "plan") => void;
   activity?: ReactNode;
+  timeline?: AssistantTimelineStep[];
   isStreaming?: boolean;
 }) {
   const assistant = message.role === "assistant";
@@ -137,11 +148,9 @@ function MessageBubble({
       return items;
     }, {});
   const parts = assistant ? assistantParts(message) : [];
-  const reasoningText = parts
-    .filter((part): part is Extract<RenderedMessagePart, { type: "reasoning" }> => part.type === "reasoning")
-    .map((part) => part.text)
-    .join("\n\n");
-  const isWaitingForFirstPart = isStreaming && !reasoningText && !parts.length;
+  const timelineSteps =
+    timeline ?? (assistant ? buildTraceTimeline(parts, message.trace ?? []) : []);
+  const isWaitingForFirstPart = isStreaming && !parts.length;
   return (
     <div className={cn("flex gap-3", !assistant && "justify-end")}>
       {assistant && (
@@ -176,24 +185,19 @@ function MessageBubble({
                 }
               }}
             >
-              {activity}
               {isWaitingForFirstPart && <ResearchOrbs />}
-              {reasoningText && (
-                <Reasoning className="mb-3" isStreaming={isStreaming}>
-                  <ReasoningTrigger
-                    getThinkingMessage={(streaming, duration) => streaming
-                      ? "正在思考"
-                      : duration
-                        ? `思考了 ${duration} 秒`
-                        : "思考过程"}
-                  />
-                  <ReasoningContent>{reasoningText}</ReasoningContent>
-                </Reasoning>
-              )}
+              <AssistantTimeline steps={timelineSteps} streaming={isStreaming} />
+              {activity}
+              <CitationContext.Provider
+                value={useMemo(
+                  () => ({ evidence: message.evidence ?? [], onInspect: () => onInspect("evidence") }),
+                  [message.evidence, onInspect],
+                )}
+              >
               {parts.map((part) => {
                 if (part.type === "markdown") {
                   const content = part.text === message.content ? renderedContent : formatEvidenceCitations(part.text, message.evidence);
-                  return <MessageResponse key={part.id} className="prose prose-sm max-w-none dark:prose-invert prose-p:my-2 prose-pre:bg-background">{content}</MessageResponse>;
+                  return <MessageResponse key={part.id} className="prose prose-sm max-w-none dark:prose-invert prose-p:my-2 prose-pre:bg-background" components={evidenceMarkdownComponents}>{content}</MessageResponse>;
                 }
                 if (part.type === "reasoning") return null;
                 const surface = part.surfaceId ? surfaces[part.surfaceId] : undefined;
@@ -203,6 +207,7 @@ function MessageBubble({
                   <div key={part.id} className="my-3 h-20 animate-pulse rounded-xl border bg-background/60" aria-label="正在生成可视化梳理" />
                 );
               })}
+              </CitationContext.Provider>
             </div>
           ) : (
             <p className="whitespace-pre-wrap">{message.content}</p>
@@ -460,6 +465,7 @@ function ResearchWorkspace({
                         }}
                         onInspect={openInspector}
                         activity={<ResearchRunActivity items={Object.values(run.items)} />}
+                        timeline={buildLiveTimeline(run)}
                         isStreaming
                       />
                     </Suspense>
@@ -497,18 +503,33 @@ function ResearchWorkspace({
                   Enter 发送 · Shift + Enter 换行 · 回答可能需要核对原始证据
                 </span>
                 <div className="flex items-center gap-1">
-                  <select
+                  <div
                     aria-label="本轮研究模式"
-                    className="h-7 rounded-md border bg-background px-2 text-xs text-muted-foreground"
-                    value={executionMode}
-                    disabled={turn.isPending || activeRuns.length > 0}
-                    onChange={(event) => setExecutionMode(event.target.value as typeof executionMode)}
+                    className="relative grid h-7 grid-cols-4 rounded-md bg-muted p-0.5"
+                    role="radiogroup"
                   >
-                    <option value="auto">自动</option>
-                    <option value="react">ReAct</option>
-                    <option value="plan_execute">Plan-Execute</option>
-                    <option value="agent_teams">Agent Teams</option>
-                  </select>
+                    <span
+                      aria-hidden
+                      className="absolute inset-y-0.5 left-0.5 w-[calc(25%-0.25rem)] rounded-[5px] bg-background shadow-sm transition-transform duration-200"
+                      style={{ transform: `translateX(${EXECUTION_MODES.findIndex((mode) => mode.value === executionMode) * 100}%)` }}
+                    />
+                    {EXECUTION_MODES.map((mode) => (
+                      <button
+                        aria-checked={executionMode === mode.value}
+                        className={cn(
+                          "relative z-10 rounded-[5px] px-2 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+                          executionMode === mode.value ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+                        )}
+                        disabled={turn.isPending || activeRuns.length > 0}
+                        key={mode.value}
+                        onClick={() => setExecutionMode(mode.value)}
+                        role="radio"
+                        type="button"
+                      >
+                        {mode.label}
+                      </button>
+                    ))}
+                  </div>
                   {contextUsage && <ContextCompositionCard usage={contextUsage} />}
                   <PromptInputSubmit
                   disabled={turn.isPending}

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -151,6 +151,10 @@ function MessageBubble({
   const timelineSteps =
     timeline ?? (assistant ? buildTraceTimeline(parts, message.trace ?? []) : []);
   const isWaitingForFirstPart = isStreaming && !parts.length;
+  const citationValue = useMemo(
+    () => ({ evidence: message.evidence ?? [], onInspect: () => onInspect("evidence") }),
+    [message.evidence, onInspect],
+  );
   return (
     <div className={cn("flex gap-3", !assistant && "justify-end")}>
       {assistant && (
@@ -188,12 +192,7 @@ function MessageBubble({
               {isWaitingForFirstPart && <ResearchOrbs />}
               <AssistantTimeline steps={timelineSteps} streaming={isStreaming} />
               {activity}
-              <CitationContext.Provider
-                value={useMemo(
-                  () => ({ evidence: message.evidence ?? [], onInspect: () => onInspect("evidence") }),
-                  [message.evidence, onInspect],
-                )}
-              >
+              <CitationContext.Provider value={citationValue}>
               {parts.map((part) => {
                 if (part.type === "markdown") {
                   const content = part.text === message.content ? renderedContent : formatEvidenceCitations(part.text, message.evidence);


### PR DESCRIPTION
## 问题(用户报告)

1. **多段思考被合并**:一轮运行里模型思考多次,前端把所有 reasoning 拼进一个组件
2. **工具调用出现在最上方**:活动块(含工具)渲染在思考/正文之前
3. **回答结束后工具调用消失**:完成态由历史消息渲染,没有活动数据
4. **引用样式**:要求使用 ai-elements 的 InlineCitation
5. **上下文卡颜色难以区分**;还有一句实现细节文案没必要
6. **模式选择**:下拉框换成滑动分段选择器

## 方案

- `live-run` 的 reducer 为每个流式 part 记录**一次到达标记**,`run.events` 成为可用的时间线日志(工具/item 事件本就按 sequence 落账)
- 新组件 `AssistantTimeline`:按真实到达顺序交错渲染——思考段用 ai-elements `Reasoning`(每段独立、可折叠、流式时展开),工具调用用 `Tool`(状态徽章,完成后保留);完成后用持久化 parts + 运行 trace 重建
- 工具区从 `ResearchRunActivity` 移除(追问队列/计划/协作任务保留,且移到时间线之后)
- 引用:`[N](#evidence-…)` 链接经 Streamdown `components` 覆盖渲染为 `InlineCitation` 徽标 + HoverCard(文档名/页码),证据数据走 React context 穿透 memo
- 上下文卡:经验证的分类色板(固定色相序、暗色档、2px 段间隙,dataviz 校验器双模式通过),删实现细节句
- 模式选择:滑动 thumb 的分段控件(radiogroup 语义)

## 验证

vitest 26/26(新增 3 例:标记唯一性、思考/工具交错顺序、V2 delta 无时间线事件);tsc 干净;eslint 0 error;已 rebase 最新 main