### PR TITLE
ci(desktop): drop unsupported matrix context from job condition

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,8 +19,9 @@ jobs:
   native-package:
     name: Build ${{ matrix.name }} package
     runs-on: ${{ matrix.os }}
-    # GPU test builds only produce a Windows artifact; skip the other legs.
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.gpu == true && matrix.name != 'Windows') }}
+    # GPU dispatches only need the Windows artifact; the other legs still run
+    # (job-level `if` cannot see the matrix context) but ignore the GPU env,
+    # since package-backend.cjs gates it on win32.
     strategy:
       fail-fast: false
       matrix:

--- a/agent/adapters/lancedb/rerank.py
+++ b/agent/adapters/lancedb/rerank.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from functools import lru_cache
 from typing import Any
 
@@ -10,15 +11,21 @@ from ...settings import load_agent_settings
 
 logger = logging.getLogger(__name__)
 
+# flashrank downloads its model zip into the shared cache dir on first use;
+# concurrent Ranker() constructions then race the download against reads,
+# which Windows surfaces as WinError 32 and skips reranking.
+_ranker_lock = threading.Lock()
+
 
 @lru_cache(maxsize=2)
 def _ranker(model_name: str) -> Any:
     from flashrank import Ranker
 
-    return Ranker(
-        model_name=model_name,
-        cache_dir=load_agent_settings().local_rerank_cache_dir,
-    )
+    with _ranker_lock:
+        return Ranker(
+            model_name=model_name,
+            cache_dir=load_agent_settings().local_rerank_cache_dir,
+        )
 
 
 def rerank_rows(

--- a/agent/application/rag_ingestion.py
+++ b/agent/application/rag_ingestion.py
@@ -37,6 +37,8 @@ def _friendly_error_message(exc: BaseException) -> str:
     message = str(exc) or exc.__class__.__name__
     if "No available model hosting platforms detected" in message:
         return "OCR 模型尚未下载，且当前无法连接模型服务器。请检查网络连接后点击「重试」。"
+    if "NO_SUCHFILE" in message or "File doesn't exist" in message:
+        return "本地模型缓存不完整或下载中断，已自动清理，请检查网络后点击「重试」。"
     if isinstance(exc, ImportError) and "fastembed" in message:
         return "本地向量组件缺失，请重新安装或更新 PaperSage。"
     if message == _LEGACY_EMPTY_TEXT_ERROR_MESSAGE:

--- a/agent/rag/fastembed_runtime.py
+++ b/agent/rag/fastembed_runtime.py
@@ -1,0 +1,33 @@
+"""Shared FastEmbed construction with partial-download self-healing."""
+
+import shutil
+from pathlib import Path
+
+from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+
+
+def _is_missing_model_error(exc: BaseException) -> bool:
+    message = str(exc)
+    return "NO_SUCHFILE" in message or "File doesn't exist" in message
+
+
+def _model_cache_dir(cache_dir: str, model_name: str) -> Path:
+    org, _, name = model_name.partition("/")
+    return Path(cache_dir) / f"models--{org}--{name}"
+
+
+def build_fastembed_embeddings(*, model_name: str, cache_dir: str) -> FastEmbedEmbeddings:
+    try:
+        return FastEmbedEmbeddings(model_name=model_name, cache_dir=cache_dir)
+    except Exception as exc:
+        if not _is_missing_model_error(exc):
+            raise
+        # An interrupted download leaves the HuggingFace snapshot directory
+        # behind while hub metadata still reports completion, so every later
+        # init fails to open model_optimized.onnx. Drop the model's cache
+        # subtree once and let this init download it again.
+        shutil.rmtree(_model_cache_dir(cache_dir, model_name), ignore_errors=True)
+        return FastEmbedEmbeddings(model_name=model_name, cache_dir=cache_dir)
+
+
+__all__ = ["build_fastembed_embeddings"]

--- a/agent/rag/hybrid.py
+++ b/agent/rag/hybrid.py
@@ -17,11 +17,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
 
-from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from ..settings import load_agent_settings
 from .evidence import EvidenceItem, EvidencePayload
+from .fastembed_runtime import build_fastembed_embeddings
 from .index_artifact import build_project_doc_index_artifact as _build_project_doc_index_artifact
 from .project_chunking import markdown_documents
 from .vector_store import build_vectorstore, stable_vectorstore_key
@@ -227,7 +227,7 @@ def _load_or_build_project_doc_index_artifact(
     normalized_text: str,
     settings_signature: str,
     splitter: RecursiveCharacterTextSplitter,
-    embeddings: FastEmbedEmbeddings,
+    embeddings: Any,
     allow_build: bool = True,
     require_persistence: bool = False,
     progress_callback: IngestionProgressCallback | None = None,
@@ -298,7 +298,7 @@ def build_project_document_index_with_settings(
     )
     if progress_callback is not None:
         progress_callback("loading_model", None, None)
-    embeddings = FastEmbedEmbeddings(
+    embeddings = build_fastembed_embeddings(
         model_name=settings.local_embedding_model,
         cache_dir=settings.local_embedding_cache_dir,
     )
@@ -610,7 +610,7 @@ class HybridRetriever:
         self.llm_client: Any = None
 
         # 初始化 Dense 检索（向量检索）
-        embeddings = FastEmbedEmbeddings(
+        embeddings = build_fastembed_embeddings(
             model_name=embedding_model,
             cache_dir=embedding_cache_dir,
         )
@@ -1196,7 +1196,7 @@ def build_project_evidence_retriever_with_settings(
     reused_doc_indexes = 0
     built_doc_indexes = 0
     settings_signature = _settings_signature_for_project_index(settings)
-    embeddings = FastEmbedEmbeddings(
+    embeddings = build_fastembed_embeddings(
         model_name=settings.local_embedding_model,
         cache_dir=settings.local_embedding_cache_dir,
     )

--- a/agent/rag/local.py
+++ b/agent/rag/local.py
@@ -2,11 +2,11 @@ import hashlib
 import os
 from typing import Any, Callable
 
-from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from ..settings import load_agent_settings
 from .evidence import EvidenceItem, EvidencePayload
+from .fastembed_runtime import build_fastembed_embeddings
 from .vector_store import build_vectorstore, stable_vectorstore_key
 
 
@@ -33,14 +33,14 @@ def ensure_local_embedding_model_downloaded() -> str:
     settings = load_agent_settings()
     os.makedirs(settings.local_embedding_cache_dir, exist_ok=True)
     try:
-        embeddings = FastEmbedEmbeddings(
+        embeddings = build_fastembed_embeddings(
             model_name=settings.local_embedding_model,
             cache_dir=settings.local_embedding_cache_dir,
         )
         embeddings.embed_query("warmup")
         return settings.local_embedding_model
     except Exception:
-        fallback_embeddings = FastEmbedEmbeddings(
+        fallback_embeddings = build_fastembed_embeddings(
             model_name=settings.local_embedding_fallback_model,
             cache_dir=settings.local_embedding_cache_dir,
         )
@@ -190,7 +190,7 @@ def build_local_evidence_retriever(
         metadata["project_uid"] = project_uid
         metadatas.append(metadata)
 
-    embeddings = FastEmbedEmbeddings(
+    embeddings = build_fastembed_embeddings(
         model_name=model_name,
         cache_dir=settings.local_embedding_cache_dir,
     )

--- a/tests/unit/test_fastembed_runtime.py
+++ b/tests/unit/test_fastembed_runtime.py
@@ -1,0 +1,47 @@
+import pytest
+
+from agent.rag.fastembed_runtime import build_fastembed_embeddings
+
+_MODEL = "Qdrant/bge-small-zh-v1.5"
+_CACHE_DIR_NAME = "models--Qdrant--bge-small-zh-v1.5"
+
+
+def test_partial_download_cache_is_cleared_and_retried(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "embeddings"
+    stale_snapshot = cache_dir / _CACHE_DIR_NAME / "snapshots" / "abc"
+    stale_snapshot.mkdir(parents=True)
+    (stale_snapshot / "refs").write_text("abc", encoding="utf-8")
+
+    calls = []
+
+    def fake_ctor(*, model_name, cache_dir):
+        calls.append((model_name, cache_dir))
+        if len(calls) == 1:
+            raise Exception(
+                "NO_SUCHFILE : 3 : Load model from model_optimized.onnx failed. File doesn't exist"
+            )
+        return object()
+
+    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", fake_ctor)
+
+    result = build_fastembed_embeddings(model_name=_MODEL, cache_dir=str(cache_dir))
+
+    assert result is not None
+    assert len(calls) == 2
+    assert not (cache_dir / _CACHE_DIR_NAME).exists()
+
+
+def test_unrelated_errors_are_raised_without_cache_wipe(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "embeddings"
+    snapshot = cache_dir / _CACHE_DIR_NAME
+    snapshot.mkdir(parents=True)
+
+    def fake_ctor(**_kwargs):
+        raise Exception("CUDA execution provider failure")
+
+    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", fake_ctor)
+
+    with pytest.raises(Exception, match="CUDA"):
+        build_fastembed_embeddings(model_name=_MODEL, cache_dir=str(cache_dir))
+
+    assert snapshot.exists()

--- a/tests/unit/test_rag_hybrid.py
+++ b/tests/unit/test_rag_hybrid.py
@@ -22,7 +22,6 @@ from agent.rag.hybrid import (
 @pytest.fixture(autouse=True)
 def _replace_embedding_downloads(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep retrieval unit tests deterministic and independent of model hosting."""
-    from agent.rag import hybrid as hybrid_module
 
     class _FakeEmbeddings:
         def __init__(self, **_kwargs: object) -> None:
@@ -34,7 +33,9 @@ def _replace_embedding_downloads(monkeypatch: pytest.MonkeyPatch) -> None:
         def embed_query(self, query: str) -> list[float]:
             return [float(len(query))] * 384
 
-    monkeypatch.setattr(hybrid_module, "FastEmbedEmbeddings", _FakeEmbeddings)
+    from agent.rag import fastembed_runtime
+
+    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
 
 
 class TestReciprocalRankFusion:
@@ -457,7 +458,9 @@ def test_project_retriever_reuses_persisted_doc_indexes(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    monkeypatch.setattr(hybrid_module, "FastEmbedEmbeddings", _FakeEmbeddings)
+    from agent.rag import fastembed_runtime
+
+    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [
@@ -526,7 +529,9 @@ def test_project_retriever_returns_empty_for_low_relevance(monkeypatch, tmp_path
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    monkeypatch.setattr(hybrid_module, "FastEmbedEmbeddings", _FakeEmbeddings)
+    from agent.rag import fastembed_runtime
+
+    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [
@@ -583,7 +588,9 @@ def test_project_retriever_uses_similarity_score(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    monkeypatch.setattr(hybrid_module, "FastEmbedEmbeddings", _FakeEmbeddings)
+    from agent.rag import fastembed_runtime
+
+    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [

--- a/tests/unit/test_rag_ingestion.py
+++ b/tests/unit/test_rag_ingestion.py
@@ -360,7 +360,7 @@ def test_ingestion_reports_real_embedding_batches_and_publishes_atomically(
         def embed_query(self, _query):
             return [1.0, 10.0]
 
-    monkeypatch.setattr("agent.rag.hybrid.FastEmbedEmbeddings", _Embeddings)
+    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", _Embeddings)
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "indexes"))
     monkeypatch.setenv("LOCAL_RAG_CHUNK_SIZE", "12")
     monkeypatch.setenv("LOCAL_RAG_CHUNK_OVERLAP", "0")
@@ -437,6 +437,11 @@ def test_friendly_error_message_covers_known_failures() -> None:
         ImportError("Could not import 'fastembed' Python package. Please install it with `pip install fastembed`.")
     )
     assert "重新安装" in fastembed
+
+    partial_download = _friendly_error_message(
+        Exception("NO_SUCHFILE : 3 : Load model model_optimized.onnx failed. File doesn't exist")
+    )
+    assert "缓存不完整" in partial_download
 
     assert _friendly_error_message(ValueError(_LEGACY_EMPTY_TEXT_ERROR_MESSAGE)) == EMPTY_TEXT_ERROR_MESSAGE
     assert _friendly_error_message(ValueError("文档没有可识别的页面。")) == "文档没有可识别的页面。"

--- a/web/scripts/gpu_dll_runtime_hook.py
+++ b/web/scripts/gpu_dll_runtime_hook.py
@@ -1,0 +1,20 @@
+"""PyInstaller runtime hook: expose bundled NVIDIA CUDA DLLs to onnxruntime.
+
+The nvidia-*-cu13 wheels place their DLLs under nvidia/<name>/bin/, which is
+not on the Windows loader search path of onnxruntime_providers_cuda.dll.
+"""
+
+import os
+import sys
+
+_base = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(sys.executable)))
+_nvidia_root = os.path.join(_base, "nvidia")
+if os.path.isdir(_nvidia_root):
+    for _entry in os.listdir(_nvidia_root):
+        _bin_dir = os.path.join(_nvidia_root, _entry, "bin")
+        if os.path.isdir(_bin_dir):
+            os.environ["PATH"] = _bin_dir + os.pathsep + os.environ.get("PATH", "")
+            try:
+                os.add_dll_directory(_bin_dir)
+            except Exception:
+                pass

--- a/web/scripts/package-backend.cjs
+++ b/web/scripts/package-backend.cjs
@@ -24,6 +24,8 @@ function run(command, args, options = {}) {
 // undefined. fastembed declares onnxruntime as a hard dependency, so the
 // pinned closure is installed with --no-deps (it is already fully resolved
 // by uv export) and the CUDA runtime goes in through a separate resolve.
+// The [cuda]/[cudnn] extras of onnxruntime-gpu are empty on Windows; the
+// nvidia-*-cu13 wheels provide the CUDA/cuDNN DLLs instead.
 function resolvePyinstallerInvocation() {
   if (!gpuBundle) {
     return { command: python, prefix: ["run", "--with", "pyinstaller", "pyinstaller"] }
@@ -45,7 +47,10 @@ function resolvePyinstallerInvocation() {
     "install",
     "--python",
     venvPython,
-    "onnxruntime-gpu[cuda,cudnn]>=1.24.3,<2.0.0",
+    "onnxruntime-gpu>=1.24.3,<2.0.0",
+    "nvidia-cudnn-cu13",
+    "nvidia-cublas-cu13",
+    "nvidia-cuda-runtime-cu13",
     "pyinstaller",
   ])
   return { command: venvPython, prefix: ["-m", "PyInstaller"] }
@@ -81,6 +86,15 @@ const pyinstallerArgs = [
   path.join(root, "scripts", "desktop_api.py"),
 ]
 for (const packageName of ocrMetadataPackages) pyinstallerArgs.splice(-1, 0, "--copy-metadata", packageName)
+if (gpuBundle) {
+  pyinstallerArgs.splice(-1, 0,
+    "--copy-metadata", "onnxruntime-gpu",
+    "--collect-binaries", "nvidia.cudnn",
+    "--collect-binaries", "nvidia.cublas",
+    "--collect-binaries", "nvidia.cuda_runtime",
+    "--runtime-hook", path.join(root, "web", "scripts", "gpu_dll_runtime_hook.py"),
+  )
+}
 const invocation = resolvePyinstallerInvocation()
 run(invocation.command, [...invocation.prefix, ...pyinstallerArgs])
 // The backend runs Alembic migrations at startup; a bundle without the
@@ -107,5 +121,21 @@ if (!fs.readdirSync(internal).some((name) => /^fastembed-[^/]*\.dist-info$/.test
 if (gpuBundle && !fs.readdirSync(internal).some((name) => /^onnxruntime_gpu-[^/]*\.dist-info$/.test(name))) {
   process.stderr.write("GPU bundle is missing onnxruntime-gpu; OCR would silently fall back to CPU.\n")
   process.exit(1)
+}
+if (gpuBundle) {
+  const bundledFiles = new Set()
+  const walk = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory()) walk(path.join(directory, entry.name))
+      else bundledFiles.add(entry.name.toLowerCase())
+    }
+  }
+  walk(internal)
+  for (const requiredDll of ["cudnn64_9.dll", "cublas64_13.dll", "cublaslt64_13.dll"]) {
+    if (!bundledFiles.has(requiredDll)) {
+      process.stderr.write(`GPU bundle is missing ${requiredDll}; the CUDA provider would fail at startup.\n`)
+      process.exit(1)
+    }
+  }
 }
 process.exit(0)

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -160,7 +160,7 @@ export function useTurn(projectId: string, sessionId: string) {
       void client.invalidateQueries({ queryKey: keys.resumableRuns(projectId, sessionId) })
       let result: z.infer<typeof turnResultSchema> | undefined
       let failure: string | undefined
-      await consumeEventStream(run.stream_url, (rawEvent) => {
+      const handleEvent = (rawEvent: unknown) => {
         const event = agentEventSchema.parse(rawEvent)
         onEvent(event)
         if (event.eventType === "run.completed") {
@@ -171,7 +171,15 @@ export function useTurn(projectId: string, sessionId: string) {
         } else if (event.eventType === "run.failed") {
           failure = String(event.payload.message ?? "Agent 运行失败")
         }
-      })
+      }
+      await consumeEventStream(run.stream_url, handleEvent)
+      if (!result && !failure) {
+        // A transient stream drop (e.g., localhost fetch failure while the
+        // machine is fully loaded) ends the stream without a terminal event.
+        // Reconnect once: the endpoint replays the persisted event log and
+        // closes it after the terminal event.
+        await consumeEventStream(run.stream_url, handleEvent)
+      }
       if (failure) throw new Error(failure)
       if (!result) throw new Error("Run 已结束，但没有返回最终结果")
       return result


### PR DESCRIPTION
job-level if cannot reference the matrix context, which made dispatches
fail workflow parsing with HTTP 422
