### PR TITLE
fix(desktop): retry the single-instance lock across update relaunches

### DIFF
--- a/web/electron/instance-lock.cjs
+++ b/web/electron/instance-lock.cjs
@@ -1,0 +1,45 @@
+/**
+ * Single-instance lock acquisition with retry.
+ *
+ * quitAndInstall relaunches the app while the previous instance may still be
+ * tearing down its tray and backend child; the OS-level lock release lags by
+ * seconds. Retrying briefly lets the relaunched instance take over instead of
+ * quitting silently (a silent quit reads as "the update broke the app").
+ *
+ * @param {{ requestLock: () => boolean, delayMs?: number, maxAttempts?: number, log: (message: string) => void, quit: () => void, onAcquired: () => void, schedule?: (callback: () => void, delayMs: number) => void }} options
+ */
+function acquireSingleInstanceLockWithRetry(options) {
+  const {
+    requestLock,
+    delayMs = 500,
+    maxAttempts = 20,
+    log,
+    quit,
+    onAcquired,
+    schedule = (callback, delay) => setTimeout(callback, delay),
+  } = options
+
+  if (requestLock()) {
+    onAcquired()
+    return
+  }
+
+  let attempts = 0
+  const retry = () => {
+    attempts += 1
+    if (requestLock()) {
+      log(`单实例锁在第 ${attempts} 次重试后获得（等待 ${(attempts * delayMs) / 1000} 秒）`)
+      onAcquired()
+      return
+    }
+    if (attempts < maxAttempts) {
+      schedule(retry, delayMs)
+      return
+    }
+    log(`另一实例持有单实例锁超过 ${(maxAttempts * delayMs) / 1000} 秒，本次启动退出`)
+    quit()
+  }
+  schedule(retry, delayMs)
+}
+
+module.exports = { acquireSingleInstanceLockWithRetry }

--- a/web/electron/instance-lock.node.cjs
+++ b/web/electron/instance-lock.node.cjs
@@ -1,0 +1,52 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+
+const { acquireSingleInstanceLockWithRetry } = require("./instance-lock.cjs")
+
+function harness({ outcomes }) {
+  const state = { acquired: 0, quit: 0, logs: [], timers: [] }
+  let calls = 0
+  acquireSingleInstanceLockWithRetry({
+    requestLock: () => outcomes[Math.min(calls++, outcomes.length - 1)],
+    delayMs: 1,
+    maxAttempts: 20,
+    log: (message) => state.logs.push(message),
+    quit: () => { state.quit += 1 },
+    onAcquired: () => { state.acquired += 1 },
+    schedule: (callback, delay) => state.timers.push({ callback, delay }),
+  })
+  return state
+}
+
+test("acquires immediately when the lock is free", () => {
+  const state = harness({ outcomes: [true] })
+  assert.equal(state.acquired, 1)
+  assert.equal(state.quit, 0)
+  assert.deepEqual(state.timers, [])
+})
+
+test("retries while the previous instance is tearing down", () => {
+  const state = harness({ outcomes: [false, false, true] })
+  assert.equal(state.acquired, 0, "acquisition waits for the retry")
+
+  state.timers.shift().callback()
+  assert.equal(state.acquired, 0)
+
+  state.timers.shift().callback()
+  assert.equal(state.acquired, 1)
+  assert.equal(state.quit, 0)
+  assert.match(state.logs[0], /第 2 次重试后获得/)
+})
+
+test("quits with a log line when the lock never frees", () => {
+  const state = harness({ outcomes: [false] })
+  for (let index = 0; index < 20; index += 1) {
+    const timer = state.timers.shift()
+    assert.ok(timer, `expected timer on attempt ${index}`)
+    timer.callback()
+  }
+  assert.equal(state.acquired, 0)
+  assert.equal(state.quit, 1)
+  assert.deepEqual(state.timers, [])
+  assert.match(state.logs[0], /持有单实例锁超过/)
+})

--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -7,6 +7,7 @@ const fs = require("node:fs")
 const { createUpdateService } = require("./updater.cjs")
 const { createTrayService } = require("./tray.cjs")
 const { createGpuPackService } = require("./gpu-pack.cjs")
+const { acquireSingleInstanceLockWithRetry } = require("./instance-lock.cjs")
 
 const apiPort = Number(process.env.PAPERSAGE_DESKTOP_PORT || 18765)
 let backend
@@ -17,10 +18,15 @@ let trayService
 
 // Updates and long migrations leave a window of seconds where no window
 // exists yet; without the lock a second impatient launch races the first.
-const hasInstanceLock = app.requestSingleInstanceLock()
-if (!hasInstanceLock) {
-  app.quit()
-}
+// quitAndInstall also relaunches while the previous instance may still be
+// tearing down its tray and backend, so retry the lock briefly instead of
+// quitting in silence — a silent quit reads as "the update broke the app".
+acquireSingleInstanceLockWithRetry({
+  requestLock: () => app.requestSingleInstanceLock(),
+  log: (message) => writeDesktopLog("main.log", message),
+  quit: () => app.quit(),
+  onAcquired: startWhenReady,
+})
 app.on("second-instance", () => showMainWindow())
 
 function getLogDirectory() {
@@ -338,7 +344,7 @@ ipcMain.handle("gpu-pack:disable", () => {
 process.on("uncaughtException", (error) => reportMainError("桌面应用发生未捕获错误", error))
 process.on("unhandledRejection", (reason) => reportMainError("桌面应用发生未处理异常", reason))
 
-if (hasInstanceLock) {
+function startWhenReady() {
   app.whenReady().then(async () => {
     trayService = createTrayService({
       Tray,

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs electron/gpu-pack.node.cjs scripts/verify-update-metadata.node.cjs && vitest run",
+    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs electron/gpu-pack.node.cjs electron/instance-lock.node.cjs scripts/verify-update-metadata.node.cjs && vitest run",
     "typecheck": "tsc -b --pretty false",
     "preview": "vite preview",
     "desktop:dev": "node electron/dev.cjs",


### PR DESCRIPTION
## 问题(用户现场:更新重启后应用没起来)

现象链:`quitAndInstall` → NSIS 静默安装并拉起新实例 → 旧实例的托盘/后端回收还需数秒,**单实例锁尚未释放** → 新实例走锁失败路径静默 `app.quit()`(该路径零日志)→ 用户看到的是"重启更新失败,什么都没起来",且日志无任何痕迹。

现场证据:更新后的应用手动启动完全正常(后端服务/端口就绪),排除安装损坏;事件日志无崩溃记录;唯一无日志的退出路径就是锁失败分支。

## 修复

- 拿不到锁时改为**带重试等待**(500ms × 20,最长 10 秒):旧实例释放锁后新实例正常接管,窗口照常出现
- 超时仍未获得才退出,且**必写日志**("另一实例持有单实例锁超过 N 秒"),消灭静默失败
- 锁获取逻辑抽成 `instance-lock.cjs` 纯函数模块(可注入计时器),配 3 个 node:test 用例:立即获得/重试后获得/超时退出

## 验证

`node --test electron/instance-lock.node.cjs` 3/3;`node --check` 通过;已挂进 `pnpm test` 链