### PR TITLE
chore: reset the rag-hybrid test baseline to its merged size

### DIFF
--- a/scripts/code_size_baseline.json
+++ b/scripts/code_size_baseline.json
@@ -5,7 +5,7 @@
     "agent/application/turn_engine.py": 560,
     "agent/rag/hybrid.py": 1665,
     "tests/unit/test_agent_evals.py": 666,
-    "tests/unit/test_rag_hybrid.py": 602,
+    "tests/unit/test_rag_hybrid.py": 609,
     "tools/mindmap-cli/main.go": 589,
     "utils/utils.py": 1772,
     "web/src/components/ai-elements/code-block.tsx": 562,


### PR DESCRIPTION
#117-#126 给 test_rag_hybrid.py 加了 7 行测试但没抬棘轮基线,导致 main 上质量门连续 3 次失败,阻塞所有 PR 的 Core 检查。抬到当前合并后的 609,此后仍只许减不许增。