### PR TITLE
feat(research): model-generated follow-up suggestions per session

### DIFF
--- a/agent/application/session_suggestions.py
+++ b/agent/application/session_suggestions.py
@@ -1,0 +1,85 @@
+"""Per-session follow-up suggestions generated from the user's model."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ..adapters.user_settings import (
+    read_api_key_for_user,
+    read_base_url_for_user,
+    read_model_name_for_user,
+)
+from ..llm_provider import build_openai_compatible_chat_model, invoke_structured_model
+
+logger = logging.getLogger(__name__)
+
+MAX_SUGGESTIONS = 4
+RECENT_MESSAGE_LIMIT = 8
+MESSAGE_SNIPPET_CHARS = 400
+
+
+class FollowUpSuggestions(BaseModel):
+    items: list[str] = Field(default_factory=list)
+
+
+_SYSTEM_PROMPT = """You propose follow-up prompts for a research assistant.
+Use the recent conversation when present, otherwise the project's library
+document list. Return up to 4 concrete next-step prompts in the user's
+language (default Chinese).
+
+Rules:
+- every item is a ready-to-send user prompt, short and specific;
+- ground items in the given context; never invent document names or claims;
+- no duplicates and no filler such as "继续" or "还有吗";
+- return JSON exactly like {"items": ["…", "…"]}."""
+
+
+def generate_session_suggestions(
+    *,
+    user_uuid: str,
+    project_uid: str,
+    session_uid: str,
+    messages: list[dict[str, Any]],
+    document_names: list[str],
+) -> list[str]:
+    """Suggest follow-up prompts; returns [] whenever no model is configured."""
+    api_key = read_api_key_for_user(uuid=user_uuid)
+    model_name = read_model_name_for_user(uuid=user_uuid)
+    if not api_key or not model_name:
+        return []
+    try:
+        model = build_openai_compatible_chat_model(
+            api_key=api_key,
+            model_name=model_name,
+            base_url=read_base_url_for_user(uuid=user_uuid),
+            temperature=0.4,
+        )
+        recent = [
+            {"role": str(item.get("role") or "user"), "content": str(item.get("content") or "")[:MESSAGE_SNIPPET_CHARS]}
+            for item in messages[-RECENT_MESSAGE_LIMIT:]
+        ]
+        payload = {
+            "project_uid": project_uid,
+            "session_uid": session_uid,
+            "recent_messages": recent,
+            "library_documents": document_names,
+        }
+        result = invoke_structured_model(
+            model,
+            FollowUpSuggestions,
+            [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+            ],
+        )
+        return [item.strip() for item in result.items if item.strip()][:MAX_SUGGESTIONS]
+    except Exception:
+        logger.exception("Session suggestions failed: session_uid=%s", session_uid)
+        return []
+
+
+__all__ = ["FollowUpSuggestions", "generate_session_suggestions"]

--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from agent.logging_utils import configure_application_logging
 
 from .context_memory_routes import context_memory_router
 from .routes import router
+from .suggestion_routes import suggestion_router
 
 
 @asynccontextmanager
@@ -36,6 +37,7 @@ app.add_middleware(
 )
 app.include_router(router)
 app.include_router(context_memory_router, prefix="/api/v1")
+app.include_router(suggestion_router, prefix="/api/v1")
 
 RESOURCE_ROOT = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parents[1]))
 WEB_DIST = RESOURCE_ROOT / "web" / "dist"

--- a/api/routes.py
+++ b/api/routes.py
@@ -46,7 +46,6 @@ from agent.application.workspace import (
     update_user_project,
     update_workspace_session,
 )
-from agent.application.session_suggestions import generate_session_suggestions
 from agent.settings import load_agent_settings
 from utils.task_queue import enqueue_background_task, get_job_status
 
@@ -285,43 +284,6 @@ def messages(
         }
     except LookupError as exc:
         raise _not_found(exc) from exc
-
-
-@router.get("/projects/{project_uid}/sessions/{session_uid}/suggestions")
-def suggestions(
-    project_uid: str,
-    session_uid: str,
-    user_uuid: UserId,
-) -> dict[str, Any]:
-    """Model-generated follow-up prompts for the session's current state."""
-    try:
-        messages = list_workspace_messages(
-            project_uid=project_uid,
-            session_uid=session_uid,
-            user_uuid=user_uuid,
-            offset=0,
-            limit=200,
-        )
-        documents = list_project_documents(project_uid=project_uid, user_uuid=user_uuid)
-    except LookupError as exc:
-        raise _not_found(exc) from exc
-    document_names = [
-        name
-        for name in (
-            str(item.get("file_name") or item.get("name") or item.get("doc_name") or "").strip()
-            for item in documents
-        )
-        if name
-    ]
-    return {
-        "suggestions": generate_session_suggestions(
-            user_uuid=user_uuid,
-            project_uid=project_uid,
-            session_uid=session_uid,
-            messages=messages,
-            document_names=document_names[:12],
-        )
-    }
 
 
 @router.post("/projects/{project_uid}/sessions/{session_uid}/turns")

--- a/api/routes.py
+++ b/api/routes.py
@@ -46,6 +46,7 @@ from agent.application.workspace import (
     update_user_project,
     update_workspace_session,
 )
+from agent.application.session_suggestions import generate_session_suggestions
 from agent.settings import load_agent_settings
 from utils.task_queue import enqueue_background_task, get_job_status
 
@@ -284,6 +285,43 @@ def messages(
         }
     except LookupError as exc:
         raise _not_found(exc) from exc
+
+
+@router.get("/projects/{project_uid}/sessions/{session_uid}/suggestions")
+def suggestions(
+    project_uid: str,
+    session_uid: str,
+    user_uuid: UserId,
+) -> dict[str, Any]:
+    """Model-generated follow-up prompts for the session's current state."""
+    try:
+        messages = list_workspace_messages(
+            project_uid=project_uid,
+            session_uid=session_uid,
+            user_uuid=user_uuid,
+            offset=0,
+            limit=200,
+        )
+        documents = list_project_documents(project_uid=project_uid, user_uuid=user_uuid)
+    except LookupError as exc:
+        raise _not_found(exc) from exc
+    document_names = [
+        name
+        for name in (
+            str(item.get("file_name") or item.get("name") or item.get("doc_name") or "").strip()
+            for item in documents
+        )
+        if name
+    ]
+    return {
+        "suggestions": generate_session_suggestions(
+            user_uuid=user_uuid,
+            project_uid=project_uid,
+            session_uid=session_uid,
+            messages=messages,
+            document_names=document_names[:12],
+        )
+    }
 
 
 @router.post("/projects/{project_uid}/sessions/{session_uid}/turns")

--- a/api/suggestion_routes.py
+++ b/api/suggestion_routes.py
@@ -1,0 +1,49 @@
+"""Model-generated follow-up suggestions for research sessions."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from agent.application.session_suggestions import generate_session_suggestions
+from agent.application.workspace import list_project_documents, list_workspace_messages
+
+from .dependencies import current_user_id
+
+suggestion_router = APIRouter()
+UserId = Annotated[str, Depends(current_user_id)]
+
+
+@suggestion_router.get("/projects/{project_uid}/sessions/{session_uid}/suggestions")
+def read_session_suggestions(
+    project_uid: str,
+    session_uid: str,
+    user_uuid: UserId,
+) -> dict[str, Any]:
+    """Model-generated follow-up prompts grounded in the session's state."""
+    messages = list_workspace_messages(
+        project_uid=project_uid,
+        session_uid=session_uid,
+        user_uuid=user_uuid,
+        offset=0,
+        limit=200,
+    )
+    documents = list_project_documents(project_uid=project_uid, user_uuid=user_uuid)
+    document_names = [
+        name
+        for name in (
+            str(item.get("file_name") or item.get("name") or item.get("doc_name") or "").strip()
+            for item in documents
+        )
+        if name
+    ]
+    return {
+        "suggestions": generate_session_suggestions(
+            user_uuid=user_uuid,
+            project_uid=project_uid,
+            session_uid=session_uid,
+            messages=messages,
+            document_names=document_names[:12],
+        )
+    }

--- a/tests/unit/test_session_suggestions.py
+++ b/tests/unit/test_session_suggestions.py
@@ -1,0 +1,67 @@
+from langchain_core.messages import AIMessage
+
+from agent.application import session_suggestions
+
+
+class _SuggestionsModel:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def invoke(self, _messages):
+        return AIMessage(content=self._content)
+
+
+def _configure(monkeypatch, model=None, key="key", name="model") -> None:
+    monkeypatch.setattr(session_suggestions, "read_api_key_for_user", lambda **_kwargs: key)
+    monkeypatch.setattr(session_suggestions, "read_model_name_for_user", lambda **_kwargs: name)
+    monkeypatch.setattr(session_suggestions, "read_base_url_for_user", lambda **_kwargs: "")
+    monkeypatch.setattr(
+        session_suggestions,
+        "build_openai_compatible_chat_model",
+        lambda **_kwargs: model,
+    )
+
+
+def test_suggestions_tolerate_reasoning_wrapped_json(monkeypatch) -> None:
+    model = _SuggestionsModel(
+        '<think>基于对话,用户在对比检索策略。</think>\n\n{"items": ["对比两种检索策略的召回率", " 总结当前证据缺口"]}'
+    )
+    _configure(monkeypatch, model=model)
+
+    items = session_suggestions.generate_session_suggestions(
+        user_uuid="u1",
+        project_uid="p1",
+        session_uid="s1",
+        messages=[{"role": "user", "content": "帮我比较检索策略"}],
+        document_names=["检索综述.pdf"],
+    )
+
+    assert items == ["对比两种检索策略的召回率", "总结当前证据缺口"]
+
+
+def test_suggestions_return_empty_without_configured_model(monkeypatch) -> None:
+    _configure(monkeypatch, model=None, key="", name="")
+
+    assert session_suggestions.generate_session_suggestions(
+        user_uuid="u1",
+        project_uid="p1",
+        session_uid="s1",
+        messages=[],
+        document_names=[],
+    ) == []
+
+
+def test_suggestions_swallow_model_failures(monkeypatch) -> None:
+    class _ExplodingModel:
+        def invoke(self, _messages):
+            raise RuntimeError("provider down")
+
+    _configure(monkeypatch, model=_ExplodingModel())
+
+    assert session_suggestions.generate_session_suggestions(
+        user_uuid="u1",
+        project_uid="p1",
+        session_uid="s1",
+        messages=[],
+        document_names=[],
+    ) == []

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -11,6 +11,7 @@ import {
   runCreatedSchema,
   runSchema,
   researchArtifactSchema,
+  sessionSuggestionsSchema,
   steeringInputSchema,
   sessionSchema,
   settingsSchema,
@@ -27,6 +28,20 @@ export const keys = {
   resumableRuns: (projectId: string, sessionId: string) => ["runs", projectId, sessionId, "resumable"] as const,
   researchArtifacts: (projectId: string, sessionId: string) => ["research-artifacts", projectId, sessionId] as const,
   settings: ["settings"] as const,
+  sessionSuggestions: (projectId: string, sessionId: string, messageCount: number) =>
+    ["session-suggestions", projectId, sessionId, messageCount] as const,
+}
+
+export function useSessionSuggestions(projectId: string, sessionId: string, messageCount: number) {
+  return useQuery({
+    queryKey: keys.sessionSuggestions(projectId, sessionId, messageCount),
+    queryFn: () => api(
+      `/projects/${projectId}/sessions/${sessionId}/suggestions`,
+      sessionSuggestionsSchema,
+    ),
+    enabled: Boolean(projectId && sessionId),
+    staleTime: 300_000,
+  });
 }
 
 export function useProjects() {

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -91,6 +91,10 @@ export const turnResultSchema = z.object({
   context_snapshot: z.record(z.string(), z.unknown()).optional(),
 })
 
+export const sessionSuggestionsSchema = z.object({
+  suggestions: z.array(z.string()),
+});
+
 export const runCreatedSchema = z.object({
   run_id: z.string(),
   status: z.string(),

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -57,6 +57,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   useMessages,
+  useSessionSuggestions,
   useProject,
   useResumableRuns,
   useSteeringInput,
@@ -268,6 +269,9 @@ function ResearchWorkspace({
 }) {
   const project = useProject(projectId);
   const messages = useMessages(projectId, sessionId);
+  const suggestionCount = messages.data?.length ?? 0;
+  const suggestions = useSessionSuggestions(projectId, sessionId, suggestionCount);
+  const suggestionItems = suggestions.data?.suggestions ?? [];
   const refetchMessages = messages.refetch;
   const resumableRuns = useResumableRuns(projectId, sessionId);
   const turn = useTurn(projectId, sessionId);
@@ -476,13 +480,9 @@ function ResearchWorkspace({
             <ConversationScrollButton />
           </Conversation>
           <div className="shrink-0 border-t bg-background p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] lg:p-5">
-            {!messages.data?.length && !turn.isPending && !activeRuns.length && (
+            {!turn.isPending && !activeRuns.length && suggestionItems.length > 0 && (
               <Suggestions className="mx-auto mb-3 max-w-3xl">
-                {[
-                  "概括这组论文的核心问题与结论",
-                  "比较不同方法的假设、数据集和局限",
-                  "找出当前证据不足、需要进一步核对的结论",
-                ].map((suggestion) => (
+                {suggestionItems.map((suggestion) => (
                   <Suggestion key={suggestion} suggestion={suggestion} onClick={submit} />
                 ))}
               </Suggestions>


### PR DESCRIPTION
## 问题(用户报告)

Suggestion 建议词条是三条写死的数据,所有项目所有会话都一样;应该是根据会话内容调模型动态生成的。

## 改动

- 后端 `GET /projects/{p}/sessions/{s}/suggestions`:有消息取最近 8 轮、空会话取资料库文档名,经 think 容错的 `invoke_structured_model` 调用户配置的模型生成 ≤4 条后续提问;未配置模型或调用失败静默降级为空(3 个单测覆盖:think 包裹 JSON、无配置、模型异常)
- 前端 `useSessionSuggestions`(键含消息数,答案完成后自动刷新,staleTime 5 分钟);建议条从"仅空会话"扩展为空闲时持续展示

## 验证

`pytest tests/unit/test_session_suggestions.py` 3/3;CI 全量