### PR TITLE
fix(desktop): heal silent updates over legacy installs and exit cleanly

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -52,14 +52,17 @@ if (WEB_DIST / "assets").is_dir():
 
 @app.get("/{path:path}", include_in_schema=False)
 def spa_fallback(path: str) -> FileResponse:
+    # The SPA entry must never come from a heuristic browser cache: after an
+    # in-place desktop update a stale entry references chunk hashes the new
+    # backend no longer ships, breaking lazy imports until the cache clears.
     candidate = ROOT_STATIC_FILES.get(path)
     if candidate and candidate.is_file():
-        return FileResponse(candidate)
+        return FileResponse(candidate, headers={"Cache-Control": "no-store"})
     if path == "index.html":
         candidate = WEB_DIST / "index.html"
         if candidate.is_file():
-            return FileResponse(candidate)
-    return FileResponse(WEB_DIST / "index.html")
+            return FileResponse(candidate, headers={"Cache-Control": "no-store"})
+    return FileResponse(WEB_DIST / "index.html", headers={"Cache-Control": "no-store"})
 
 
 def run() -> None:

--- a/tests/unit/test_spa_cache_headers.py
+++ b/tests/unit/test_spa_cache_headers.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+
+from api import main as api_main
+from api.main import app
+
+
+def test_spa_entry_is_served_without_caching(tmp_path, monkeypatch) -> None:
+    """A heuristic-cached entry page breaks lazy imports after an in-place update."""
+    (tmp_path / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setattr(api_main, "WEB_DIST", tmp_path)
+    monkeypatch.setattr(api_main, "ROOT_STATIC_FILES", {})
+    client = TestClient(app)
+
+    for path in ("/", "/research/some-route"):
+        response = client.get(path)
+
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-store"

--- a/web/build/installer.nsh
+++ b/web/build/installer.nsh
@@ -14,3 +14,39 @@
     ${EndIf}
   FunctionEnd
 !macroend
+
+; Silent updates (auto-update always installs silently) die in the built-in
+; "uninstall old version" step when the previously installed build shipped an
+; uninstaller from an older NSIS generation: ExecWait reports 2 and the whole
+; update aborts. Heal it here instead: in silent mode only, run the previous
+; uninstaller synchronously with the directory pin (the mode that reliably
+; works) and clear its registration, so the installer proceeds as a fresh
+; install instead of delegating to the incompatible built-in step.
+!macro customInit
+  IfSilent 0 silentUninstallDone
+    ReadRegStr $R0 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}" "UninstallString"
+    ${If} $R0 != ""
+      ; UninstallString is "<installDir>\Uninstall PaperSage.exe" /currentuser.
+      StrCpy $R1 $R0 "" 1
+      StrLen $R2 $R1
+      StrCpy $R3 0
+      ${Do}
+        StrCpy $R4 $R1 1 $R3
+        ${If} $R4 == '"'
+          ${Break}
+        ${EndIf}
+        IntOp $R3 $R3 + 1
+      ${LoopUntil} $R3 >= $R2
+      StrCpy $R5 $R1 $R3
+      ${GetParent} $R5 $R6
+      IfFileExists "$R5" 0 silentUninstallSkip
+        ClearErrors
+        ExecWait '"$R5" /S _?=$R6' $R7
+        ; Best effort: even a failed old uninstaller must not wedge the
+        ; update; dropping the registration makes this a fresh install.
+        DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}"
+        StrCpy $INSTDIR $R6
+    ${EndIf}
+  silentUninstallSkip:
+  silentUninstallDone:
+!macroend

--- a/web/electron/backend-shutdown.cjs
+++ b/web/electron/backend-shutdown.cjs
@@ -1,0 +1,37 @@
+/**
+ * Backend process-tree shutdown.
+ *
+ * A plain child.kill() only terminates the launcher process; the packaged
+ * backend spawns grandchildren (OCR workers) that survive the app, keep the
+ * API port bound, and outlive "exit" for the user. On Windows the reliable
+ * way is taskkill /T; elsewhere child.kill() delivers SIGTERM and Python
+ * shuts down gracefully.
+ *
+ * @param {import("node:child_process").ChildProcess | undefined} child
+ * @param {{ platform?: NodeJS.Platform, spawnKill?: (command: string, args: string[]) => void, kill?: (child: import("node:child_process").ChildProcess) => void }} [options]
+ */
+function shutdownBackendTree(child, options = {}) {
+  const { platform = process.platform, spawnKill = defaultSpawnKill, kill = defaultKill } = options
+  if (!child || child.killed || child.pid == null) return false
+  if (platform === "win32") {
+    spawnKill("taskkill", ["/pid", String(child.pid), "/T", "/F"])
+    return true
+  }
+  try {
+    kill(child)
+  } catch {
+    // The child already exited between the check and the signal.
+  }
+  return true
+}
+
+function defaultSpawnKill(command, args) {
+  const { spawn } = require("node:child_process")
+  spawn(command, args, { stdio: "ignore", windowsHide: true })
+}
+
+function defaultKill(child) {
+  child.kill()
+}
+
+module.exports = { shutdownBackendTree }

--- a/web/electron/backend-shutdown.node.cjs
+++ b/web/electron/backend-shutdown.node.cjs
@@ -1,0 +1,42 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+
+const { shutdownBackendTree } = require("./backend-shutdown.cjs")
+
+function fakeChild({ pid = 4242, killed = false } = {}) {
+  return { pid, killed, killCalls: 0, get killed_() { return killed }, kill() { this.killCalls += 1 } }
+}
+
+test("kills the whole tree with taskkill on Windows", () => {
+  const calls = []
+  const child = fakeChild()
+  const handled = shutdownBackendTree(child, {
+    platform: "win32",
+    spawnKill: (command, args) => calls.push([command, args]),
+    kill: () => assert.fail("taskkill path must not call child.kill()"),
+  })
+  assert.equal(handled, true)
+  assert.deepEqual(calls, [["taskkill", ["/pid", "4242", "/T", "/F"]]])
+  assert.equal(child.killCalls, 0)
+})
+
+test("signals the launcher directly on other platforms", () => {
+  const child = fakeChild({ pid: 17 })
+  shutdownBackendTree(child, {
+    platform: "linux",
+    spawnKill: () => assert.fail("linux path must not spawn taskkill"),
+    kill: (candidate) => candidate.kill(),
+  })
+  assert.equal(child.killCalls, 1)
+})
+
+test("ignores missing or already-dead children without throwing", () => {
+  assert.equal(shutdownBackendTree(undefined, { platform: "win32", spawnKill: () => {} }), false)
+  assert.equal(
+    shutdownBackendTree(fakeChild({ killed: true }), { platform: "win32", spawnKill: () => {} }),
+    false,
+  )
+  const pidless = fakeChild()
+  pidless.pid = undefined
+  assert.equal(shutdownBackendTree(pidless, { platform: "linux", kill: () => {} }), false)
+})

--- a/web/electron/main.cjs
+++ b/web/electron/main.cjs
@@ -8,6 +8,7 @@ const { createUpdateService } = require("./updater.cjs")
 const { createTrayService } = require("./tray.cjs")
 const { createGpuPackService } = require("./gpu-pack.cjs")
 const { acquireSingleInstanceLockWithRetry } = require("./instance-lock.cjs")
+const { shutdownBackendTree } = require("./backend-shutdown.cjs")
 
 const apiPort = Number(process.env.PAPERSAGE_DESKTOP_PORT || 18765)
 let backend
@@ -367,5 +368,7 @@ app.on("window-all-closed", () => { if (process.platform !== "darwin" && (!trayS
 app.on("activate", showMainWindow)
 app.on("before-quit", () => {
   trayService?.beginQuit()
-  if (backend && !backend.killed) backend.kill()
+  // Kill the whole backend tree: plain kill() leaves OCR grandchildren
+  // running with the API port still bound after the app exits.
+  shutdownBackendTree(backend)
 })

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs electron/gpu-pack.node.cjs electron/instance-lock.node.cjs scripts/verify-update-metadata.node.cjs && vitest run",
+    "test": "node --test electron/updater.node.cjs electron/tray.node.cjs electron/gpu-pack.node.cjs electron/instance-lock.node.cjs electron/backend-shutdown.node.cjs scripts/verify-update-metadata.node.cjs && vitest run",
     "typecheck": "tsc -b --pretty false",
     "preview": "vite preview",
     "desktop:dev": "node electron/dev.cjs",


### PR DESCRIPTION
## 两个问题(用户现场)

1. **老用户静默更新必失败**:1.5.1 → 新版的自动/手动静默更新都死在内置"卸载旧版"步骤(ExecWait 2,弹窗"Failed to uninstall old application files"),重试无解。实验定位:旧版卸载器被新安装器以不兼容方式调起;用 `_?=` 目录钉住的同步调用则 100% 成功。当前版本互更(exit 0)正常——受影响的是带着旧代卸载器的存量安装。
2. **退出关不干净**:`before-quit` 只 `kill()` 后端主进程,OCR 子进程树存活,API 端口仍被占用。

## 修复

- `installer.nsh` 新增 `customInit`:**仅静默模式**下,自己以 `_?=安装目录` 同步执行旧卸载器(实测可靠的方式),并清除其注册表项 + 沿用原安装目录——内置步骤查不到旧版即按全新安装继续;老卸载器即使失败也清注册表,更新不再被卡死。UI 安装路径不受影响
- 新增 `backend-shutdown.cjs`:Windows 上 `taskkill /pid <pid> /T /F` 杀整棵进程树,其他平台保持 SIGTERM 优雅退出;3 个 node:test 用例(win 走 taskkill、posix 走 kill、缺参/已死不抛)

## 验证

分支已触发 desktop-release 实测:nsh 编译通过 + 产物将在带 1.7.0 存量安装的机器上做真实覆盖安装验证(结果回填)。node 测试 6/6。