### PR TITLE
feat(web): pop the mode switch from a compact active-mode indicator

### DIFF
--- a/web/src/components/mode-selector.tsx
+++ b/web/src/components/mode-selector.tsx
@@ -1,0 +1,74 @@
+import { ChevronDown } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export const EXECUTION_MODES = [
+  { value: "auto", label: "自动" },
+  { value: "react", label: "ReAct" },
+  { value: "plan_execute", label: "计划执行" },
+  { value: "agent_teams", label: "团队协作" },
+] as const;
+
+export type ExecutionMode = (typeof EXECUTION_MODES)[number]["value"];
+
+/**
+ * Compact indicator of the active research mode; clicking it pops the
+ * sliding segmented switch. Matches the prompt toolbar's ghost controls.
+ */
+export function ModeSelector({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: ExecutionMode;
+  onChange: (mode: ExecutionMode) => void;
+  disabled?: boolean;
+}) {
+  const activeIndex = EXECUTION_MODES.findIndex((mode) => mode.value === value);
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          aria-label="本轮研究模式"
+          className={cn(
+            "flex h-7 items-center gap-1 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60 data-open:bg-accent data-open:text-foreground",
+          )}
+          disabled={disabled}
+          type="button"
+        >
+          {EXECUTION_MODES[activeIndex]?.label ?? "自动"}
+          <ChevronDown className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto p-2">
+        <div
+          aria-label="切换研究模式"
+          className="relative grid h-8 w-64 grid-cols-4 rounded-md bg-muted p-0.5"
+          role="radiogroup"
+        >
+          <span
+            aria-hidden
+            className="absolute inset-y-0.5 left-0.5 w-[calc(25%-0.25rem)] rounded-[5px] bg-background shadow-sm transition-transform duration-200"
+            style={{ transform: `translateX(${Math.max(0, activeIndex) * 100}%)` }}
+          />
+          {EXECUTION_MODES.map((mode) => (
+            <button
+              aria-checked={value === mode.value}
+              className={cn(
+                "relative z-10 rounded-[5px] px-1 text-xs transition-colors",
+                value === mode.value ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              key={mode.value}
+              onClick={() => onChange(mode.value)}
+              role="radio"
+              type="button"
+            >
+              {mode.label}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg bg-popover p-4 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -15,6 +15,7 @@ import { A2UIMindmap } from "@/components/a2ui-mindmap";
 import { EvidenceCitations } from "@/components/evidence-citations";
 import { ResearchOrbs } from "@/components/agent-status";
 import { ContextCompositionCard } from "@/components/context-composition";
+import { ModeSelector, type ExecutionMode } from "@/components/mode-selector";
 import { PageError } from "@/components/page-state";
 import {
   Message as AiMessage,
@@ -77,13 +78,6 @@ import { agentEventSchema, turnResultSchema } from "@/lib/schemas";
 import type { AgentEvent, Message, TurnResult } from "@/lib/schemas";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/stores/ui-store";
-
-const EXECUTION_MODES = [
-  { value: "auto", label: "自动" },
-  { value: "react", label: "ReAct" },
-  { value: "plan_execute", label: "计划执行" },
-  { value: "agent_teams", label: "团队协作" },
-] as const;
 
 const ResearchInspector = lazy(async () => {
   const module = await import("@/components/research-inspector");
@@ -276,7 +270,7 @@ function ResearchWorkspace({
   const resumableRuns = useResumableRuns(projectId, sessionId);
   const turn = useTurn(projectId, sessionId);
   const steeringInput = useSteeringInput(projectId, sessionId);
-  const [executionMode, setExecutionMode] = useState<"auto" | "react" | "plan_execute" | "agent_teams">("auto");
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>("auto");
   const [lastTurn, setLastTurn] = useState<TurnResult>();
   const [liveRuns, setLiveRuns] = useState<Record<string, LiveRun>>({});
   const resumedRunIds = useRef(new Set<string>());
@@ -502,33 +496,11 @@ function ResearchWorkspace({
                   Enter 发送 · Shift + Enter 换行 · 回答可能需要核对原始证据
                 </span>
                 <div className="flex items-center gap-1">
-                  <div
-                    aria-label="本轮研究模式"
-                    className="relative grid h-7 grid-cols-4 rounded-md bg-muted p-0.5"
-                    role="radiogroup"
-                  >
-                    <span
-                      aria-hidden
-                      className="absolute inset-y-0.5 left-0.5 w-[calc(25%-0.25rem)] rounded-[5px] bg-background shadow-sm transition-transform duration-200"
-                      style={{ transform: `translateX(${EXECUTION_MODES.findIndex((mode) => mode.value === executionMode) * 100}%)` }}
-                    />
-                    {EXECUTION_MODES.map((mode) => (
-                      <button
-                        aria-checked={executionMode === mode.value}
-                        className={cn(
-                          "relative z-10 rounded-[5px] px-2 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60",
-                          executionMode === mode.value ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-                        )}
-                        disabled={turn.isPending || activeRuns.length > 0}
-                        key={mode.value}
-                        onClick={() => setExecutionMode(mode.value)}
-                        role="radio"
-                        type="button"
-                      >
-                        {mode.label}
-                      </button>
-                    ))}
-                  </div>
+                  <ModeSelector
+                    value={executionMode}
+                    onChange={setExecutionMode}
+                    disabled={turn.isPending || activeRuns.length > 0}
+                  />
                   {contextUsage && <ContextCompositionCard usage={contextUsage} />}
                   <PromptInputSubmit
                   disabled={turn.isPending}


### PR DESCRIPTION
按用户交互意图调整:模式选择不再常驻四段条,改为**当前模式指示器 + 点击弹出滑动切换器**。

- 新增 vendored `ui/popover.tsx`(radix-ui 整包,样式对齐 dropdown-menu 的 ring/圆角/动效)
- 新组件 `mode-selector.tsx`:ghost 触发器显示当前模式名 + ChevronDown,Radix Popover 内含滑块分段(radiogroup 语义),主题 token 全走 popover/muted/accent
- research-page 收敛为单行调用,页面减负(行数棘轮友好)

## 验证

CI 全量(typecheck + vitest + Electron shell)