### PR TITLE
fix(web): keep a2ui mindmaps inline after a turn completes

### DIFF
--- a/web/src/lib/live-run.ts
+++ b/web/src/lib/live-run.ts
@@ -1,5 +1,5 @@
 import { applyA2UIEnvelope, applyA2UISurfaceMetadata, type A2UISurface } from "@/lib/a2ui"
-import type { AgentEvent } from "@/lib/schemas"
+import type { AgentEvent, Message } from "@/lib/schemas"
 
 export type RenderedMessagePart =
   | { id: string; type: "markdown"; text: string }
@@ -106,10 +106,12 @@ function applyItemEvent(run: LiveRun, event: AgentEvent): LiveRun {
       : null
     const surfaces = { ...run.surfaces }
     if (nextSurface) surfaces[nextSurface.surfaceId] = nextSurface
-    const parts = run.parts.some((part) => part.id === partId)
-      ? run.parts.map((part) => part.id === partId && part.type === "a2ui" && nextSurface ? { ...part, surfaceId: nextSurface.surfaceId } : part)
-      : item.status === "failed"
-        ? run.parts
+    // A failed presentation never receives envelopes; dropping its placeholder
+    // part keeps a skeleton from pulsing until the run refetches.
+    const parts = item.status === "failed"
+      ? run.parts.filter((part) => part.id !== partId)
+      : run.parts.some((part) => part.id === partId)
+        ? run.parts.map((part) => part.id === partId && part.type === "a2ui" && nextSurface ? { ...part, surfaceId: nextSurface.surfaceId } : part)
         : [...run.parts, { id: partId, type: "a2ui" as const, surfaceId: nextSurface?.surfaceId }]
     return { ...run, items, surfaces, parts }
   }
@@ -136,4 +138,30 @@ export function reduceLiveRun(run: LiveRun, event: AgentEvent): LiveRun {
 
 export function liveAnswer(parts: RenderedMessagePart[]): string {
   return parts.reduce((answer, part) => part.type === "markdown" ? answer + part.text : answer, "")
+}
+
+export function assistantParts(message: Message): RenderedMessagePart[] {
+  const stored: RenderedMessagePart[] = []
+  message.parts?.forEach((part, index) => {
+    const type = part.type
+    if (type === "markdown" && typeof part.text === "string") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `text-${index}`, type, text: part.text })
+      return
+    }
+    if (type === "reasoning" && typeof part.text === "string") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `reasoning-${index}`, type, text: part.text })
+      return
+    }
+    if (type === "a2ui") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `surface-${index}`, type, surfaceId: typeof part.surfaceId === "string" ? part.surfaceId : undefined })
+    }
+  })
+  if (stored.length) return stored
+  const legacySurfaces = Array.isArray(message.a2ui) ? message.a2ui : [message.a2ui]
+  return [
+    ...(message.content ? [{ id: "text-0", type: "markdown" as const, text: message.content }] : []),
+    ...legacySurfaces.flatMap((surface, index) => typeof surface?.surfaceId === "string"
+      ? [{ id: `surface-${index}`, type: "a2ui" as const, surfaceId: surface.surfaceId }]
+      : []),
+  ]
 }

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -218,6 +218,7 @@ export function useTurn(projectId: string, sessionId: string) {
           plan: result.agent_plan ?? result.plan,
           todos: result.todos,
           a2ui: result.a2ui_surface,
+          parts: result.response_parts,
         },
       ])
       void client.invalidateQueries({ queryKey: keys.messages(projectId, sessionId) })

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -88,6 +88,7 @@ export const turnResultSchema = z.object({
   phase_path: z.string().default(""),
   used_document_rag: z.boolean().default(false),
   a2ui_surface: z.record(z.string(), z.unknown()).nullable().optional(),
+  response_parts: z.array(z.record(z.string(), z.unknown())).optional(),
   context_snapshot: z.record(z.string(), z.unknown()).optional(),
 })
 

--- a/web/src/lib/turn-parts.test.ts
+++ b/web/src/lib/turn-parts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { assistantParts, createLiveRun, reduceLiveRun } from "@/lib/live-run"
+import { turnResultSchema } from "@/lib/schemas"
+import type { AgentEvent, Message } from "@/lib/schemas"
+
+function itemEvent(item: NonNullable<AgentEvent["item"]>, sequence: number): AgentEvent {
+  return {
+    version: 2,
+    eventId: `evt_${sequence}`,
+    eventType: "item.delta",
+    sequence,
+    timestamp: "",
+    threadId: "",
+    runId: "",
+    traceId: "",
+    payload: {},
+    item,
+  }
+}
+
+describe("turn completion keeps the inline part order", () => {
+  it("parses response_parts from the run result so the completion message can render inline", () => {
+    const parsed = turnResultSchema.parse({
+      answer: "正文",
+      response_parts: [
+        { id: "text-0", type: "markdown", text: "正文前半" },
+        { id: "surface-0", type: "a2ui", surfaceId: "research-map-1" },
+        { id: "text-1", type: "markdown", text: "正文后半" },
+      ],
+    })
+    expect(parsed.response_parts?.map((part) => part.id)).toEqual(["text-0", "surface-0", "text-1"])
+  })
+
+  it("renders persisted interleaved parts in order instead of appending surfaces after the text", () => {
+    const message: Message = {
+      role: "assistant",
+      content: "全文",
+      parts: [
+        { id: "text-0", type: "markdown", text: "正文前半" },
+        { id: "surface-0", type: "a2ui", surfaceId: "research-map-1" },
+        { id: "text-1", type: "markdown", text: "正文后半" },
+      ],
+    }
+    expect(assistantParts(message).map((part) => part.id)).toEqual(["text-0", "surface-0", "text-1"])
+  })
+
+  it("keeps the legacy text-then-surface fallback for messages stored before parts existed", () => {
+    const message: Message = {
+      role: "assistant",
+      content: "全文",
+      a2ui: [{ surfaceId: "research-map-1" }],
+    }
+    expect(assistantParts(message).map((part) => part.id)).toEqual(["text-0", "surface-0"])
+  })
+})
+
+describe("live presentation failure", () => {
+  it("drops the placeholder part when the fragment fails so no skeleton lingers", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, itemEvent({ id: "item_presentation_surface-0", type: "presentation", status: "in_progress", payload: { partId: "surface-0", presentation: "a2ui" } }, 1))
+    run = reduceLiveRun(run, itemEvent({ id: "item_presentation_surface-0", type: "presentation", status: "failed", payload: { partId: "surface-0", message: "UI fragment ended before its closing tag" } }, 2))
+    expect(run.parts.find((part) => part.id === "surface-0")).toBeUndefined()
+  })
+})

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -68,11 +68,11 @@ import { formatEvidenceCitations } from "@/lib/evidence";
 import { sessionContextUsage } from "@/lib/context-usage";
 import { consumeEventStream } from "@/lib/api";
 import {
+  assistantParts,
   createLiveRun,
   liveAnswer,
   reduceLiveRun,
   type LiveRun,
-  type RenderedMessagePart,
 } from "@/lib/live-run";
 import { agentEventSchema, turnResultSchema } from "@/lib/schemas";
 import type { AgentEvent, Message, TurnResult } from "@/lib/schemas";
@@ -88,32 +88,6 @@ const ResearchRunActivity = lazy(async () => {
   const module = await import("@/components/research-run-activity");
   return { default: module.ResearchRunActivity };
 });
-
-function assistantParts(message: Message): RenderedMessagePart[] {
-  const stored: RenderedMessagePart[] = [];
-  message.parts?.forEach((part, index) => {
-    const type = part.type;
-    if (type === "markdown" && typeof part.text === "string") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `text-${index}`, type, text: part.text });
-      return;
-    }
-    if (type === "reasoning" && typeof part.text === "string") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `reasoning-${index}`, type, text: part.text });
-      return;
-    }
-    if (type === "a2ui") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `surface-${index}`, type, surfaceId: typeof part.surfaceId === "string" ? part.surfaceId : undefined });
-    }
-  });
-  if (stored.length) return stored;
-  const legacySurfaces = Array.isArray(message.a2ui) ? message.a2ui : [message.a2ui];
-  return [
-    ...(message.content ? [{ id: "text-0", type: "markdown" as const, text: message.content }] : []),
-    ...legacySurfaces.flatMap((surface, index) => typeof surface?.surfaceId === "string"
-      ? [{ id: `surface-${index}`, type: "a2ui" as const, surfaceId: surface.surfaceId }]
-      : []),
-  ];
-}
 
 function MessageBubble({
   message,


### PR DESCRIPTION
## 问题

用户反馈 a2ui 思维导图"渲染处空白/跑到页面最下面"。

## 根因

1. **位置排错(主体)**:turn 完成瞬间 `useTurn.onSuccess` 插入缓存的消息没有 `parts` 字段——`turnResultSchema` 未声明 `response_parts`(zod 剥掉了服务端返回的字段),`onSuccess` 也没传。于是 `assistantParts` 走 legacy 回退:整篇正文一个大 text part 先渲染、思维导图追加在消息最底部,直到 messages refetch 拿到持久化 parts 才归位。
2. **失败残留**:V2 `item.failed`(presentation)不移除已插入的占位 part,骨架会一直闪到 run 结束(V1 分支有移除逻辑,V2 分支漏了)。

## 修复

- `turnResultSchema` 声明可选 `response_parts`
- `onSuccess` 完成消息带上 `parts: result.response_parts`
- live-run V2 presentation 分支在 `status === "failed"` 时过滤占位 part
- `assistantParts` 移入 `lib/live-run.ts` 并导出(纯函数,可单测)

## 验证

- 用桌面版真实数据库(`papersage-web/database.sqlite`)重放真实事件与持久化消息,均正确出图;浏览器实测 18 节点 / 11 引用按钮内联渲染
- 新增 `turn-parts.test.ts` 4 个测试(先红后绿);vitest 33/33、`tsc --noEmit` 干净