### PR TITLE
fix(desktop): use the Electron net module for the GPU pack download

### DIFF
--- a/web/electron/gpu-pack.cjs
+++ b/web/electron/gpu-pack.cjs
@@ -14,6 +14,35 @@ function isGpuPackApplied(internalDir) {
 }
 
 /**
+ * rename(2) cannot cross volume boundaries (EXDEV), and the pack is staged
+ * under userData while the backend lives in the installation directory,
+ * which are regularly on different drives. Fall back to copy+delete then.
+ * @param {string} source
+ * @param {string} destination
+ */
+function moveDirectory(source, destination) {
+  try {
+    fs.renameSync(source, destination)
+  } catch (error) {
+    const code = error && error.code
+    if (code !== "EXDEV" && code !== "EPERM") throw error
+    fs.cpSync(source, destination, { recursive: true })
+    fs.rmSync(source, { recursive: true, force: true })
+  }
+}
+
+/** Put the backed-up CPU onnxruntime tree back and drop the NVIDIA tree. */
+function restoreBackup(internalDir) {
+  const backup = path.join(internalDir, BACKUP_DIR)
+  if (!fs.existsSync(backup)) {
+    throw new Error("未找到 CPU 版备份，无法还原；请重新安装 PaperSage。")
+  }
+  fs.rmSync(path.join(internalDir, "onnxruntime"), { recursive: true, force: true })
+  fs.rmSync(path.join(internalDir, "nvidia"), { recursive: true, force: true })
+  moveDirectory(backup, path.join(internalDir, "onnxruntime"))
+}
+
+/**
  * Swap the CPU onnxruntime tree for the CUDA one from the downloaded pack.
  * The runtime hook baked into every bundle puts the nvidia bin directories
  * on the DLL search path, so no bootloader change is needed.
@@ -31,8 +60,8 @@ function applyPack(internalDir, stagingDir) {
     fs.renameSync(path.join(internalDir, "onnxruntime"), backup)
   }
   fs.rmSync(path.join(internalDir, "onnxruntime"), { recursive: true, force: true })
-  fs.renameSync(stagedOnnxruntime, path.join(internalDir, "onnxruntime"))
-  fs.renameSync(stagedNvidia, path.join(internalDir, "nvidia"))
+  moveDirectory(stagedOnnxruntime, path.join(internalDir, "onnxruntime"))
+  moveDirectory(stagedNvidia, path.join(internalDir, "nvidia"))
 }
 
 /**
@@ -70,19 +99,22 @@ function createGpuPackService({ internalDir, workDir, download, extract, report 
       setPhase("gpu-active")
     } catch (error) {
       logger.error("PaperSage GPU pack installation failed", error)
+      // A half-applied pack leaves the backend without onnxruntime at all;
+      // restore the CPU tree so the next launch still parses documents.
+      if (!fs.existsSync(path.join(internalDir, "onnxruntime"))) {
+        try {
+          restoreBackup(internalDir)
+        } catch (restoreError) {
+          logger.error("PaperSage GPU pack rollback failed", restoreError)
+        }
+      }
       setPhase("error", { error: error instanceof Error ? error.message : String(error) })
     }
   }
 
   const disable = () => {
     try {
-      const backup = path.join(internalDir, BACKUP_DIR)
-      if (!fs.existsSync(backup)) {
-        throw new Error("未找到 CPU 版备份，无法还原；请重新安装 PaperSage。")
-      }
-      fs.rmSync(path.join(internalDir, "onnxruntime"), { recursive: true, force: true })
-      fs.rmSync(path.join(internalDir, "nvidia"), { recursive: true, force: true })
-      fs.renameSync(backup, path.join(internalDir, "onnxruntime"))
+      restoreBackup(internalDir)
       setPhase("cpu-active")
       return true
     } catch (error) {
@@ -95,4 +127,4 @@ function createGpuPackService({ internalDir, workDir, download, extract, report 
   return { enable, disable, status: () => ({ phase }) }
 }
 
-module.exports = { BACKUP_DIR, applyPack, createGpuPackService, isGpuPackApplied }
+module.exports = { BACKUP_DIR, applyPack, createGpuPackService, isGpuPackApplied, moveDirectory, restoreBackup }

--- a/web/electron/gpu-pack.node.cjs
+++ b/web/electron/gpu-pack.node.cjs
@@ -84,3 +84,75 @@ test("an incomplete pack fails without touching the CPU tree", async () => {
   assert.ok(!fs.existsSync(path.join(sandbox.internalDir, BACKUP_DIR)))
   fs.rmSync(sandbox.root, { recursive: true, force: true })
 })
+
+test("enable falls back to copy+delete when staging crosses drives (EXDEV)", async (t) => {
+  const { mock } = require("node:test")
+  const sandbox = makeSandbox()
+  t.after(() => {
+    mock.restoreAll()
+    fs.rmSync(sandbox.root, { recursive: true, force: true })
+  })
+  // Only moves out of the staging tree are cross-volume; renames inside the
+  // internal tree (the backup) keep working, as they do on a real machine.
+  const originalRename = fs.renameSync
+  mock.method(fs, "renameSync", (source, destination) => {
+    if (source.startsWith(sandbox.workDir)) {
+      throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" })
+    }
+    originalRename(source, destination)
+  })
+  const service = createGpuPackService({
+    internalDir: sandbox.internalDir,
+    workDir: sandbox.workDir,
+    download: async (_url, destination) => fs.writeFileSync(destination, "zip", "utf8"),
+    extract: async (_zipPath, stagingDir) => fakeExtract(stagingDir),
+    report: () => undefined,
+    logger: { error: () => undefined },
+  })
+
+  await service.enable("https://example.invalid/pack.zip")
+
+  assert.equal(service.status().phase, "gpu-active")
+  assert.ok(fs.existsSync(path.join(sandbox.internalDir, "onnxruntime", "gpu.txt")))
+  assert.ok(fs.existsSync(path.join(sandbox.internalDir, "nvidia", "cudnn", "bin", "cudnn64_9.dll")))
+  assert.ok(fs.existsSync(path.join(sandbox.internalDir, BACKUP_DIR, "cpu.txt")))
+  assert.ok(!fs.existsSync(path.join(sandbox.workDir, "staging", "onnxruntime")))
+})
+
+test("enable rolls the CPU tree back when the swap dies mid-flight", async (t) => {
+  const { mock } = require("node:test")
+  const sandbox = makeSandbox()
+  const errors = []
+  t.after(() => {
+    mock.restoreAll()
+    fs.rmSync(sandbox.root, { recursive: true, force: true })
+  })
+  // Cross-volume staging forces the copy path, and the onnxruntime copy (the
+  // first cpSync of the swap) fails; the internal tree must roll back to CPU.
+  const originalRename = fs.renameSync
+  mock.method(fs, "renameSync", (source, destination) => {
+    if (source.startsWith(sandbox.workDir)) {
+      throw Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" })
+    }
+    originalRename(source, destination)
+  })
+  mock.method(fs, "cpSync", () => {
+    throw new Error("disk full")
+  })
+  const service = createGpuPackService({
+    internalDir: sandbox.internalDir,
+    workDir: sandbox.workDir,
+    download: async (_url, destination) => fs.writeFileSync(destination, "zip", "utf8"),
+    extract: async (_zipPath, stagingDir) => fakeExtract(stagingDir),
+    report: () => undefined,
+    logger: { error: (_message, error) => errors.push(error) },
+  })
+
+  await service.enable("https://example.invalid/pack.zip")
+
+  assert.equal(service.status().phase, "error")
+  assert.ok(fs.existsSync(sandbox.cpuMarker))
+  assert.ok(!fs.existsSync(path.join(sandbox.internalDir, BACKUP_DIR)))
+  assert.ok(!fs.existsSync(path.join(sandbox.internalDir, "nvidia")))
+  assert.ok(errors.length >= 1)
+})


### PR DESCRIPTION
main.cjs resolves net to node:net for the backend port probe, so the
GPU pack downloader crashed with "net.request is not a function" the
moment the enable button was clicked.
