### PR TITLE
fix(agent): salvage unterminated UI fragments and repair update_plan tool dispatch

### DIFF
--- a/agent/application/a2ui_fragments.py
+++ b/agent/application/a2ui_fragments.py
@@ -66,6 +66,7 @@ class A2UIFragmentStreamParser:
         self._text_buffer = ""
         self._fragment_buffer = ""
         self._fragment_type = ""
+        self._fragment_open_tag = ""
         self._in_code_fence = False
 
     def feed(self, token: str) -> None:
@@ -91,6 +92,7 @@ class A2UIFragmentStreamParser:
         if match.start():
             self._emit_text(self._text_buffer[:match.start()])
         self._fragment_type = match.group("type")
+        self._fragment_open_tag = match.group(0)
         if self._on_fragment_start is not None:
             self._on_fragment_start(self._fragment_type)
         self._fragment_buffer = self._text_buffer[match.end():]
@@ -98,10 +100,16 @@ class A2UIFragmentStreamParser:
         self._consume_fragment("")
 
     def finish(self) -> None:
-        """Flush plain text and discard an incomplete private fragment."""
+        """Flush plain text and fail an unterminated private fragment.
+
+        The swallowed fragment text is salvaged back into the markdown stream:
+        models sometimes reference the tag in prose (e.g. inside inline code),
+        and discarding the buffer would truncate the answer mid-sentence.
+        """
         if self._fragment_type:
             self._on_error("UI fragment ended before its closing tag")
-            self._fragment_buffer = self._fragment_type = ""
+            self._emit_text(self._fragment_open_tag + self._fragment_buffer)
+            self._fragment_buffer = self._fragment_type = self._fragment_open_tag = ""
         if self._text_buffer:
             self._emit_text(self._text_buffer)
             self._text_buffer = ""
@@ -125,7 +133,7 @@ class A2UIFragmentStreamParser:
         self._fragment_buffer += token
         if len(self._fragment_buffer.encode("utf-8")) > _MAX_FRAGMENT_BYTES:
             self._on_error("UI fragment exceeded the size limit")
-            self._fragment_buffer = self._fragment_type = ""
+            self._fragment_buffer = self._fragment_type = self._fragment_open_tag = ""
             return
         close = self._fragment_buffer.find(_CLOSE_UI)
         if close < 0:
@@ -133,7 +141,7 @@ class A2UIFragmentStreamParser:
         raw_xml = self._fragment_buffer[:close]
         remainder = self._fragment_buffer[close + len(_CLOSE_UI):]
         fragment = parse_ui_fragment(self._fragment_type, raw_xml)
-        self._fragment_buffer = self._fragment_type = ""
+        self._fragment_buffer = self._fragment_type = self._fragment_open_tag = ""
         if fragment is None:
             self._on_error("UI fragment did not match its registered schema")
         else:

--- a/agent/application/a2ui_output_contract.py
+++ b/agent/application/a2ui_output_contract.py
@@ -41,7 +41,9 @@ For example:
 
 Use it for a genuine hierarchy, not as decoration. Omit it when prose is clearer.
 Use only evidence refs returned by document tools in this turn. The server renders XML
-privately through its registered catalog; the XML fragment itself is never visible to the user."""
+privately through its registered catalog; the XML fragment itself is never visible to the user.
+Never mention, quote, or wrap the fragment tags or XML in backticks or code fences inside
+your answer. If the user asks how the visual was produced, describe it in plain words."""
 
 
 def build_a2ui_output_contract() -> str:

--- a/agent/session_factory.py
+++ b/agent/session_factory.py
@@ -196,7 +196,9 @@ def _tool_schema_level() -> str:
 def _serialize_tool_args_schema(tool_item: Any, *, schema_level: str) -> str:
     if schema_level == "manifest":
         return ""
-    args_schema = getattr(tool_item, "args_schema", None)
+    # tool_call_schema is the model-facing contract; args_schema may carry
+    # runtime-injected fields that must not be advertised to the model.
+    args_schema = getattr(tool_item, "tool_call_schema", None) or getattr(tool_item, "args_schema", None)
     if args_schema is None or not hasattr(args_schema, "model_json_schema"):
         return ""
     try:

--- a/agent/tools/plan_tools.py
+++ b/agent/tools/plan_tools.py
@@ -28,6 +28,11 @@ class UpdatePlanInput(BaseModel):
     revision: int = Field(ge=0)
     goal: str = Field(min_length=1, max_length=1000)
     steps: list[PlanStep] = Field(default_factory=list, max_length=64)
+    # Injected args live in the schema (not just the signature) so the
+    # ToolNode both injects them and hides them from the model-facing contract.
+    # Defaults keep args_schema validation usable with model-only arguments.
+    tool_call_id: Annotated[str, InjectedToolCallId] = ""
+    state: Annotated[dict[str, Any], InjectedState] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_dependencies(self) -> "UpdatePlanInput":

--- a/tests/unit/test_a2ui_fragments.py
+++ b/tests/unit/test_a2ui_fragments.py
@@ -16,14 +16,27 @@ def test_stream_parser_keeps_markdown_and_hides_complete_ui_fragment() -> None:
     assert fragments[0].payload["root"]["citation_ids"] == ["chunk-1"]
 
 
-def test_stream_parser_discards_incomplete_ui_fragment() -> None:
+def test_stream_parser_salvages_incomplete_ui_fragment_as_text() -> None:
     text: list[str] = []
     errors: list[str] = []
     parser = A2UIFragmentStreamParser(on_text=text.append, on_fragment=lambda _item: None, on_error=errors.append)
     parser.feed("正文\n<ui type=\"research-map\"><map title=\"x\">")
     parser.finish()
 
-    assert "".join(text) == "正文\n"
+    # A model may reference the tag in prose; discarding the buffer would
+    # truncate the answer mid-sentence, so the swallowed text is returned.
+    assert "".join(text) == '正文\n<ui type="research-map"><map title="x">'
+    assert errors == ["UI fragment ended before its closing tag"]
+
+
+def test_stream_parser_salvages_prose_after_inline_tag_mention() -> None:
+    text: list[str] = []
+    errors: list[str] = []
+    parser = A2UIFragmentStreamParser(on_text=text.append, on_fragment=lambda _item: None, on_error=errors.append)
+    parser.feed("思维导图是用 `\n<ui type=\"research-map\"> 这样的私有 XML 画的。\n后续说明。")
+    parser.finish()
+
+    assert "".join(text) == "思维导图是用 `\n<ui type=\"research-map\"> 这样的私有 XML 画的。\n后续说明。"
     assert errors == ["UI fragment ended before its closing tag"]
 
 

--- a/tests/unit/test_plan_tools.py
+++ b/tests/unit/test_plan_tools.py
@@ -42,3 +42,80 @@ def test_update_plan_validates_dependency_ids() -> None:
         assert "dependencies" in str(exc)
     else:
         raise AssertionError("Expected dependency validation failure")
+
+
+def test_update_plan_tool_call_schema_hides_injected_args() -> None:
+    fields = sorted(update_plan.tool_call_schema.model_json_schema().get("properties", {}).keys())
+    assert fields == ["goal", "revision", "steps"]
+
+
+def test_update_plan_runs_through_agent_tool_node() -> None:
+    """Regression: the injected args must be supplied by the ToolNode.
+
+    Before the fix the explicit args_schema dropped the InjectedToolCallId /
+    InjectedState annotations, so calling update_plan crashed with
+    ``missing 2 required positional arguments: 'tool_call_id' and 'state'``
+    and failed the whole run (run_2bf2fdfc, 2026-08-16).
+    """
+    from typing import Any
+
+    from langchain.agents import create_agent
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+    from langchain_core.tools import BaseTool
+
+    from agent.middlewares.plan import plan_middleware
+    from agent.tools.plan_tools import read_plan
+
+    class ScriptedToolModel(BaseChatModel):
+        script: list[dict[str, Any]] = []
+
+        def bind_tools(self, tools: list[BaseTool | dict[str, Any]], **kwargs: Any) -> "ScriptedToolModel":
+            return self
+
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: Any = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            step = self.script[0] if self.script else {"text": "完成"}
+            object.__setattr__(self, "script", self.script[1:])
+            message = AIMessage(content=step.get("text", ""), tool_calls=step.get("tool_calls", []))
+            return ChatResult(generations=[ChatGeneration(message=message)])
+
+        @property
+        def _llm_type(self) -> str:
+            return "scripted"
+
+    model = ScriptedToolModel(
+        script=[
+            {
+                "tool_calls": [
+                    {
+                        "name": "update_plan",
+                        "args": {"revision": 0, "goal": "核验论文", "steps": [{"id": "evidence", "title": "收集证据"}]},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ]
+            },
+            {"text": "完成"},
+        ]
+    )
+    agent = create_agent(
+        model=model,
+        tools=[update_plan, read_plan],
+        system_prompt="test",
+        middleware=[plan_middleware],
+    )
+    result = agent.invoke({"messages": [{"role": "user", "content": "做个计划"}]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert tool_messages, "expected a tool result for update_plan"
+    assert "missing" not in str(tool_messages[0].content)
+    assert "revision 0 saved" in str(tool_messages[0].content)
+    assert result.get("plan", {}).get("revision") == 0

--- a/web/src/lib/live-run.ts
+++ b/web/src/lib/live-run.ts
@@ -1,5 +1,5 @@
 import { applyA2UIEnvelope, applyA2UISurfaceMetadata, type A2UISurface } from "@/lib/a2ui"
-import type { AgentEvent } from "@/lib/schemas"
+import type { AgentEvent, Message } from "@/lib/schemas"
 
 export type RenderedMessagePart =
   | { id: string; type: "markdown"; text: string }
@@ -106,10 +106,12 @@ function applyItemEvent(run: LiveRun, event: AgentEvent): LiveRun {
       : null
     const surfaces = { ...run.surfaces }
     if (nextSurface) surfaces[nextSurface.surfaceId] = nextSurface
-    const parts = run.parts.some((part) => part.id === partId)
-      ? run.parts.map((part) => part.id === partId && part.type === "a2ui" && nextSurface ? { ...part, surfaceId: nextSurface.surfaceId } : part)
-      : item.status === "failed"
-        ? run.parts
+    // A failed presentation never receives envelopes; dropping its placeholder
+    // part keeps a skeleton from pulsing until the run refetches.
+    const parts = item.status === "failed"
+      ? run.parts.filter((part) => part.id !== partId)
+      : run.parts.some((part) => part.id === partId)
+        ? run.parts.map((part) => part.id === partId && part.type === "a2ui" && nextSurface ? { ...part, surfaceId: nextSurface.surfaceId } : part)
         : [...run.parts, { id: partId, type: "a2ui" as const, surfaceId: nextSurface?.surfaceId }]
     return { ...run, items, surfaces, parts }
   }
@@ -136,4 +138,30 @@ export function reduceLiveRun(run: LiveRun, event: AgentEvent): LiveRun {
 
 export function liveAnswer(parts: RenderedMessagePart[]): string {
   return parts.reduce((answer, part) => part.type === "markdown" ? answer + part.text : answer, "")
+}
+
+export function assistantParts(message: Message): RenderedMessagePart[] {
+  const stored: RenderedMessagePart[] = []
+  message.parts?.forEach((part, index) => {
+    const type = part.type
+    if (type === "markdown" && typeof part.text === "string") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `text-${index}`, type, text: part.text })
+      return
+    }
+    if (type === "reasoning" && typeof part.text === "string") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `reasoning-${index}`, type, text: part.text })
+      return
+    }
+    if (type === "a2ui") {
+      stored.push({ id: typeof part.id === "string" ? part.id : `surface-${index}`, type, surfaceId: typeof part.surfaceId === "string" ? part.surfaceId : undefined })
+    }
+  })
+  if (stored.length) return stored
+  const legacySurfaces = Array.isArray(message.a2ui) ? message.a2ui : [message.a2ui]
+  return [
+    ...(message.content ? [{ id: "text-0", type: "markdown" as const, text: message.content }] : []),
+    ...legacySurfaces.flatMap((surface, index) => typeof surface?.surfaceId === "string"
+      ? [{ id: `surface-${index}`, type: "a2ui" as const, surfaceId: surface.surfaceId }]
+      : []),
+  ]
 }

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -218,6 +218,7 @@ export function useTurn(projectId: string, sessionId: string) {
           plan: result.agent_plan ?? result.plan,
           todos: result.todos,
           a2ui: result.a2ui_surface,
+          parts: result.response_parts,
         },
       ])
       void client.invalidateQueries({ queryKey: keys.messages(projectId, sessionId) })

--- a/web/src/lib/schemas.ts
+++ b/web/src/lib/schemas.ts
@@ -88,6 +88,7 @@ export const turnResultSchema = z.object({
   phase_path: z.string().default(""),
   used_document_rag: z.boolean().default(false),
   a2ui_surface: z.record(z.string(), z.unknown()).nullable().optional(),
+  response_parts: z.array(z.record(z.string(), z.unknown())).optional(),
   context_snapshot: z.record(z.string(), z.unknown()).optional(),
 })
 

--- a/web/src/lib/turn-parts.test.ts
+++ b/web/src/lib/turn-parts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { assistantParts, createLiveRun, reduceLiveRun } from "@/lib/live-run"
+import { turnResultSchema } from "@/lib/schemas"
+import type { AgentEvent, Message } from "@/lib/schemas"
+
+function itemEvent(item: NonNullable<AgentEvent["item"]>, sequence: number): AgentEvent {
+  return {
+    version: 2,
+    eventId: `evt_${sequence}`,
+    eventType: "item.delta",
+    sequence,
+    timestamp: "",
+    threadId: "",
+    runId: "",
+    traceId: "",
+    payload: {},
+    item,
+  }
+}
+
+describe("turn completion keeps the inline part order", () => {
+  it("parses response_parts from the run result so the completion message can render inline", () => {
+    const parsed = turnResultSchema.parse({
+      answer: "正文",
+      response_parts: [
+        { id: "text-0", type: "markdown", text: "正文前半" },
+        { id: "surface-0", type: "a2ui", surfaceId: "research-map-1" },
+        { id: "text-1", type: "markdown", text: "正文后半" },
+      ],
+    })
+    expect(parsed.response_parts?.map((part) => part.id)).toEqual(["text-0", "surface-0", "text-1"])
+  })
+
+  it("renders persisted interleaved parts in order instead of appending surfaces after the text", () => {
+    const message: Message = {
+      role: "assistant",
+      content: "全文",
+      parts: [
+        { id: "text-0", type: "markdown", text: "正文前半" },
+        { id: "surface-0", type: "a2ui", surfaceId: "research-map-1" },
+        { id: "text-1", type: "markdown", text: "正文后半" },
+      ],
+    }
+    expect(assistantParts(message).map((part) => part.id)).toEqual(["text-0", "surface-0", "text-1"])
+  })
+
+  it("keeps the legacy text-then-surface fallback for messages stored before parts existed", () => {
+    const message: Message = {
+      role: "assistant",
+      content: "全文",
+      a2ui: [{ surfaceId: "research-map-1" }],
+    }
+    expect(assistantParts(message).map((part) => part.id)).toEqual(["text-0", "surface-0"])
+  })
+})
+
+describe("live presentation failure", () => {
+  it("drops the placeholder part when the fragment fails so no skeleton lingers", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, itemEvent({ id: "item_presentation_surface-0", type: "presentation", status: "in_progress", payload: { partId: "surface-0", presentation: "a2ui" } }, 1))
+    run = reduceLiveRun(run, itemEvent({ id: "item_presentation_surface-0", type: "presentation", status: "failed", payload: { partId: "surface-0", message: "UI fragment ended before its closing tag" } }, 2))
+    expect(run.parts.find((part) => part.id === "surface-0")).toBeUndefined()
+  })
+})

--- a/web/src/pages/research-page.tsx
+++ b/web/src/pages/research-page.tsx
@@ -68,11 +68,11 @@ import { formatEvidenceCitations } from "@/lib/evidence";
 import { sessionContextUsage } from "@/lib/context-usage";
 import { consumeEventStream } from "@/lib/api";
 import {
+  assistantParts,
   createLiveRun,
   liveAnswer,
   reduceLiveRun,
   type LiveRun,
-  type RenderedMessagePart,
 } from "@/lib/live-run";
 import { agentEventSchema, turnResultSchema } from "@/lib/schemas";
 import type { AgentEvent, Message, TurnResult } from "@/lib/schemas";
@@ -88,32 +88,6 @@ const ResearchRunActivity = lazy(async () => {
   const module = await import("@/components/research-run-activity");
   return { default: module.ResearchRunActivity };
 });
-
-function assistantParts(message: Message): RenderedMessagePart[] {
-  const stored: RenderedMessagePart[] = [];
-  message.parts?.forEach((part, index) => {
-    const type = part.type;
-    if (type === "markdown" && typeof part.text === "string") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `text-${index}`, type, text: part.text });
-      return;
-    }
-    if (type === "reasoning" && typeof part.text === "string") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `reasoning-${index}`, type, text: part.text });
-      return;
-    }
-    if (type === "a2ui") {
-      stored.push({ id: typeof part.id === "string" ? part.id : `surface-${index}`, type, surfaceId: typeof part.surfaceId === "string" ? part.surfaceId : undefined });
-    }
-  });
-  if (stored.length) return stored;
-  const legacySurfaces = Array.isArray(message.a2ui) ? message.a2ui : [message.a2ui];
-  return [
-    ...(message.content ? [{ id: "text-0", type: "markdown" as const, text: message.content }] : []),
-    ...legacySurfaces.flatMap((surface, index) => typeof surface?.surfaceId === "string"
-      ? [{ id: `surface-${index}`, type: "a2ui" as const, surfaceId: surface.surfaceId }]
-      : []),
-  ];
-}
 
 function MessageBubble({
   message,


### PR DESCRIPTION
## 背景

来自今天用户桌面端(1.8.3)真实数据库的三连报障排查,两个新根因:

## 修复

### 1. 未闭合 UI 片段截断正文(a2ui)
模型在正文中**引用**私有 XML 语法(如行内反引号包裹 `<ui type="research-map">`)时,解析器进入片段缓冲,流结束后整个尾部被丢弃——正文被拦腰截断(实测 run_226722a2:正文停在"是用 `",后续全被吞),占位符也被移除。

- `finish()` 现在把吞掉的文本(含开标签)原样归还 markdown 流,保住答案完整性;错误事件照发,占位照删。
- 输出合同新增禁止条款:不得在答案中引用/反引号包裹片段语法。

### 2. update_plan 工具调度崩溃(整 run 失败)
`@tool(args_schema=UpdatePlanInput)` 显式 schema 丢失了函数签名上的 `InjectedToolCallId` / `InjectedState` 注解,ToolNode 不注入参数,裸调直接 `TypeError: missing 2 required positional arguments`(实测 run_2bf2fdfc,"用 plan 研究一下 diffusion" 整个 run 失败)。该工具上线以来首次被模型真实调用即触发。

- 注解字段移入 `UpdatePlanInput`(带默认值以兼容纯模型参数校验),模型可见 schema 自动隐藏注入字段。
- `_build_tool_specs` 改读 `tool_call_schema`,注入字段不再泄入工具清单提示。
- 回归测试:经真实 `create_agent`+ToolNode 调用 update_plan 全链路断言。

## 测试
- 后端 348 passed(含新增断言)
- web 30 passed
- 复现脚本验证:修复前裸 agent 即复现 TypeError,修复后 ToolMessage = "Plan revision 0 saved."
