### PR TITLE
feat(agent): Codex-parity subagent controls

### DIFF
--- a/agent/application/delegation_service.py
+++ b/agent/application/delegation_service.py
@@ -19,29 +19,40 @@ def submit_delegated_agent_task(
     description: str,
     mode: str = "join",
     plan_step_id: str | None = None,
+    context_note: str | None = None,
     db_name: str = "./database.sqlite",
 ) -> tuple[dict[str, Any], bool]:
     """Persist one bounded child task and its V2 item projection."""
     normalized_role = role.strip()
     normalized_description = description.strip()
     normalized_parent_task_uid = (parent_task_uid or "").strip()
+    normalized_context_note = (context_note or "").strip()
     if not normalized_role or not normalized_description:
         raise ValueError("Delegated task role and description are required")
     if mode != "join":
         raise ValueError("Only join delegation is currently supported")
+    input_payload: dict[str, Any] = {
+        "objective": normalized_description,
+        "coordination_mode": mode,
+        "tool_call_id": tool_call_id,
+    }
+    if normalized_context_note:
+        input_payload["context_note"] = normalized_context_note[:4000]
     task, created = create_agent_task(
         run_uid=run_uid,
         parent_task_uid=normalized_parent_task_uid or None,
         kind=AgentTaskKind.SUBAGENT,
         agent_role=normalized_role,
         idempotency_key=f"leader-tool:{tool_call_id}",
-        input_payload={
-            "objective": normalized_description,
-            "coordination_mode": mode,
-            "tool_call_id": tool_call_id,
-        },
+        input_payload=input_payload,
         db_name=db_name,
     )
+    from ..subagent.loader import load_subagent_definitions
+
+    display_names = {
+        definition.name: definition.display_name
+        for definition in load_subagent_definitions()
+    }
     append_run_item_event(
         run_uid=run_uid,
         item_uid=f"item_agent_task_{task['task_uid']}",
@@ -49,7 +60,11 @@ def submit_delegated_agent_task(
         task_uid=str(task["task_uid"]),
         status="in_progress",
         event_type="item.created",
-        payload={"agent": normalized_role, "task": normalized_description, "summary": "已加入任务队列"},
+        payload={
+            "agent": display_names.get(normalized_role) or normalized_role,
+            "task": normalized_description,
+            "summary": "已加入任务队列",
+        },
         db_name=db_name,
     )
     if created and plan_step_id:

--- a/agent/application/subagent_task_executor.py
+++ b/agent/application/subagent_task_executor.py
@@ -51,6 +51,8 @@ def execute_subagent_task_payload(
     objective = str(task_input.get("objective") or "").strip()
     if not objective:
         raise ValueError("Subagent task objective is required")
+    context_note = str(task_input.get("context_note") or "").strip()
+    prompt = f"{objective}\n\n[背景上下文]\n{context_note}" if context_note else objective
 
     project_uid = str(context["project_uid"])
     session_uid = str(context["session_uid"])
@@ -74,15 +76,16 @@ def execute_subagent_task_payload(
             user_uuid=user_uuid,
         ),
         options=AgentRuntimeOptions(
-            llm=_model_for_user(user_uuid),
+            llm=_model_for_user(user_uuid, preferred_model=definition.model),
             project_name=str(project.get("project_name") or "未命名项目"),
             scope_summary="项目资料库可用；需要查看文件目录时调用 list_document",
             thread_id=f"subagent:{task_uid}",
+            max_turn_tokens=subagent_token_budget(),
         ),
     )
     try:
         result = execute_agent_center_turn(
-            request=AgentCenterTurnRequest(prompt=objective),
+            request=AgentCenterTurnRequest(prompt=prompt),
             deps=AgentCenterRuntimeDeps(
                 leader_agent=session.agent,
                 leader_runtime_config={"configurable": {**session.runtime_config["configurable"], "task_uid": task_uid}},
@@ -110,10 +113,10 @@ def _profile_for(definition: SubAgentDefinition) -> AgentProfile:
     )
 
 
-def _model_for_user(user_uuid: str) -> Any:
-    """Build the user-configured provider model without persisting credentials."""
+def _model_for_user(user_uuid: str, *, preferred_model: str | None = None) -> Any:
+    """Build the provider model; role-declared models override the user default."""
     api_key = read_api_key_for_user(uuid=user_uuid)
-    model_name = read_model_name_for_user(uuid=user_uuid)
+    model_name = (preferred_model or "").strip() or read_model_name_for_user(uuid=user_uuid)
     if not api_key or not model_name:
         raise ValueError("Model provider is not configured")
     return build_openai_compatible_chat_model(
@@ -121,6 +124,22 @@ def _model_for_user(user_uuid: str) -> Any:
         model_name=model_name,
         base_url=read_base_url_for_user(uuid=user_uuid),
     )
+
+
+# Codex-style hard per-thread budget: when provider usage crosses it the agent
+# loses its tools on the next call and must deliver what it has gathered.
+DEFAULT_SUBAGENT_TOKEN_BUDGET = 150_000
+
+
+def subagent_token_budget() -> int:
+    import os
+
+    configured = str(os.getenv("PAPERSAGE_SUBAGENT_TOKEN_BUDGET", "") or "").strip()
+    try:
+        value = int(configured)
+    except ValueError:
+        return DEFAULT_SUBAGENT_TOKEN_BUDGET
+    return value if value > 0 else DEFAULT_SUBAGENT_TOKEN_BUDGET
 
 
 def _sanitize_result(

--- a/agent/middlewares/budget.py
+++ b/agent/middlewares/budget.py
@@ -1,0 +1,67 @@
+"""Runtime-enforced token budget for one agent thread (Codex rollout-budget style).
+
+Unlike prompt-level budgets ("at most N searches"), this middleware counts the
+provider-reported token usage of every assistant message already in thread
+state and, once the total crosses the limit, strips the model request down to
+a no-tools finalize call so the agent delivers what it has instead of looping
+until failure.
+"""
+
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
+
+# Deterministic finalize instruction injected once the budget is exhausted.
+_BUDGET_EXHAUSTED_INSTRUCTION = (
+    "[系统提示] 本任务的 token 预算已耗尽。不要再调用任何工具。"
+    "立即基于已收集的信息交付最终结果;未能覆盖的问题列入「未决问题」。"
+)
+
+
+def used_tokens(messages: list[AnyMessage]) -> int:
+    """Sum provider-reported total tokens across assistant messages."""
+    total = 0
+    for message in messages:
+        usage = getattr(message, "usage_metadata", None)
+        if isinstance(message, AIMessage) and isinstance(usage, dict):
+            value = usage.get("total_tokens")
+            if isinstance(value, int) and value > 0:
+                total += value
+    return total
+
+
+class TokenBudgetMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Cap one thread's total model tokens; finalize instead of failing."""
+
+    def __init__(self, budget_tokens: int) -> None:
+        super().__init__()
+        if budget_tokens <= 0:
+            raise ValueError("budget_tokens must be positive")
+        self._budget_tokens = budget_tokens
+
+    @property
+    def budget_tokens(self) -> int:
+        return self._budget_tokens
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Any,
+    ) -> ModelResponse[Any]:
+        messages = list(request.state.get("messages", [])) if request.state else []
+        if used_tokens(messages) < self._budget_tokens:
+            return handler(request)
+        # Codex-style hard stop: no tools remain on the next call, so the model
+        # response ends the agent loop with a delivery instead of another round.
+        return handler(
+            request.override(
+                tools=[],
+                tool_choice="none",
+                messages=[*messages, HumanMessage(content=_BUDGET_EXHAUSTED_INSTRUCTION)],
+            )
+        )
+
+
+__all__ = ["TokenBudgetMiddleware", "used_tokens"]

--- a/agent/middlewares/builder.py
+++ b/agent/middlewares/builder.py
@@ -11,6 +11,7 @@ from openai import RateLimitError
 
 from ..context_governance import compact_trigger_ratio, model_context_window_tokens
 from ..subagent.loader import load_subagent_definitions
+from .budget import TokenBudgetMiddleware
 from .durable_delegation import DurableDelegationMiddleware
 from .llm_logger import llm_logger_middleware
 from .model_output_validation import (
@@ -42,9 +43,13 @@ def build_middleware_list(
     deps: Any | None = None,
     enable_auto_summarization: bool = True,
     enable_tool_selector: bool = True,
+    max_turn_tokens: int | None = None,
 ) -> list[AgentMiddleware[Any, Any, Any]]:
     """Build complete middleware list for agent runtime."""
     middleware_list: list[AgentMiddleware[Any, Any, Any]] = []
+
+    if max_turn_tokens is not None:
+        middleware_list.append(TokenBudgetMiddleware(max_turn_tokens))
 
     if _is_enabled(profile, "trace"):
         middleware_list.append(TraceMiddleware())

--- a/agent/middlewares/durable_delegation.py
+++ b/agent/middlewares/durable_delegation.py
@@ -20,6 +20,15 @@ class DelegateTaskInput(BaseModel):
     description: str = Field(min_length=1, description="Concrete research objective for this task.")
     mode: str = Field(default="join", description="Coordination mode; only join is currently supported.")
     plan_step_id: str | None = Field(default=None, description="Optional existing plan step to execute.")
+    context_note: str | None = Field(
+        default=None,
+        max_length=4000,
+        description=(
+            "Context snapshot for the child: the user's original question plus any "
+            "established conclusions the child must respect. Include whenever the "
+            "objective alone does not fully restate what the user asked."
+        ),
+    )
 
 
 class DurableDelegationMiddleware(AgentMiddleware):
@@ -34,7 +43,11 @@ class DurableDelegationMiddleware(AgentMiddleware):
         self.system_prompt = (
             "Use `delegate_task` only when a distinct evidence task is useful. "
             "It creates durable work and returns its stable task UID; it does not run "
-            "a child synchronously. Do not delegate recursively.\n\nAvailable roles:\n" + available
+            "a child synchronously. Do not delegate recursively.\n"
+            "The child only sees what you send: give each task a self-contained "
+            "objective, and pass `context_note` with the user's original question and "
+            "any established conclusions whenever the objective alone does not fully "
+            "restate them.\n\nAvailable roles:\n" + available
         )
         self.tools = [self._build_tool()]
 
@@ -47,6 +60,7 @@ class DurableDelegationMiddleware(AgentMiddleware):
             runtime: ToolRuntime,
             mode: str = "join",
             plan_step_id: str | None = None,
+            context_note: str | None = None,
         ) -> str:
             normalized_role = role.strip()
             if normalized_role not in roles:
@@ -68,6 +82,7 @@ class DurableDelegationMiddleware(AgentMiddleware):
                 description=description,
                 mode=mode,
                 plan_step_id=plan_step_id,
+                context_note=context_note,
                 db_name=db_name,
             )
             if created:

--- a/agent/session_factory.py
+++ b/agent/session_factory.py
@@ -41,6 +41,8 @@ class AgentRuntimeOptions:
     system_prompt: str | None = None
     enable_tool_selector: bool | None = None
     thread_id: str | None = None
+    max_turn_tokens: int | None = None
+    """Hard per-thread model-token budget; finalize instead of failing when hit."""
 
 
 @dataclass(frozen=True)
@@ -91,6 +93,7 @@ def create_agent_session(
         profile=profile,
         deps=deps,
         enable_tool_selector=enable_tool_selector,
+        max_turn_tokens=options.max_turn_tokens,
     )
     tool_specs = _build_tool_specs([*tools, *_collect_middleware_tools(middleware)])
     checkpointer, checkpoint_connection = _build_checkpointer()

--- a/agent/subagent/loader.py
+++ b/agent/subagent/loader.py
@@ -15,6 +15,8 @@ class SubAgentDefinition:
     system_prompt: str
     capability_ids: tuple[str, ...]
     model: str | None = None
+    display_name: str = ""
+    """Human-readable label; falls back to ``name`` when absent."""
 
 
 def load_subagent_definitions(base_dir: str | Path | None = None) -> list[SubAgentDefinition]:
@@ -79,6 +81,7 @@ def _parse_agent_md(file_path: Path) -> SubAgentDefinition:
         system_prompt=system_prompt,
         capability_ids=capability_ids,
         model=metadata.get("model", "").strip() or None,
+        display_name=metadata.get("display_name", "").strip(),
     )
 
 

--- a/agent/subagent/researcher/agent.md
+++ b/agent/subagent/researcher/agent.md
@@ -1,5 +1,6 @@
 ---
 name: researcher
+display_name: 检索研究员
 description: 自主迭代检索的研究代理:子问题拆解、多轮查询工程、引文链追踪、开放获取论文载入资料库,交付可溯源证据包
 capabilities: document_pack, paper_pack, web_pack, skill_pack
 ---

--- a/agent/subagent/reviewer/agent.md
+++ b/agent/subagent/reviewer/agent.md
@@ -1,5 +1,6 @@
 ---
 name: reviewer
+display_name: 审阅研究员
 description: 证据审查代理:逐条核验结论与证据的对应性、充分性与一致性,输出分级判定与修正建议
 capabilities: document_pack, paper_pack, skill_pack
 ---

--- a/agent/subagent/writer/agent.md
+++ b/agent/subagent/writer/agent.md
@@ -1,5 +1,6 @@
 ---
 name: writer
+display_name: 写作研究员
 description: 综合写作代理:把已核验证据整合为结构化、断言强度校准、逐点溯源的最终文稿,不引入新事实
 capabilities: skill_pack
 ---

--- a/tests/unit/test_budget_middleware.py
+++ b/tests/unit/test_budget_middleware.py
@@ -1,0 +1,81 @@
+"""TokenBudgetMiddleware behavior (Codex rollout-budget analogue)."""
+
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
+
+from agent.middlewares.budget import TokenBudgetMiddleware, used_tokens
+
+
+def test_used_tokens_sums_provider_reported_totals() -> None:
+    messages = [
+        AIMessage(content="a", usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}),
+        HumanMessage(content="b"),
+        AIMessage(content="c", usage_metadata={"input_tokens": 20, "output_tokens": 5, "total_tokens": 25}),
+        AIMessage(content="no usage"),
+    ]
+    assert used_tokens(messages) == 40
+
+
+def _fake_request(state_messages: list[Any], tools: list[Any]) -> Any:
+    from langchain.agents.middleware.types import ModelRequest
+
+    return ModelRequest(
+        model=_DummyModel(),
+        messages=list(state_messages),
+        tools=list(tools),
+        state={"messages": list(state_messages)},
+    )
+
+
+class _DummyModel:
+    pass
+
+
+@tool
+def _probe() -> str:
+    """Probe tool."""
+    return "ok"
+
+
+def _recording_handler(seen: list[Any]):
+    def handler(request: Any) -> str:
+        seen.append(request)
+        return "response"
+
+    return handler
+
+
+def test_budget_passes_through_below_limit() -> None:
+    seen: list[Any] = []
+    request = _fake_request(
+        [AIMessage(content="m", usage_metadata={"input_tokens": 5, "output_tokens": 5, "total_tokens": 10})],
+        [_probe],
+    )
+    result = TokenBudgetMiddleware(budget_tokens=100).wrap_model_call(request, _recording_handler(seen))
+    assert result == "response"
+    assert seen[0] is request  # unchanged request below the budget
+
+
+def test_budget_finalizes_without_tools_at_limit() -> None:
+    seen: list[Any] = []
+    heavy = AIMessage(
+        content="m",
+        usage_metadata={"input_tokens": 500, "output_tokens": 500, "total_tokens": 1000},
+    )
+    request = _fake_request([heavy], [_probe])
+    TokenBudgetMiddleware(budget_tokens=500).wrap_model_call(request, _recording_handler(seen))
+    finalized = seen[0]
+    assert finalized.tools == []
+    assert finalized.tool_choice == "none"
+    injected = finalized.messages[-1]
+    assert "token 预算已耗尽" in injected.content
+    assert any("未决问题" in part for part in [injected.content])
+
+
+def test_budget_rejects_non_positive_limit() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        TokenBudgetMiddleware(budget_tokens=0)

--- a/tests/unit/test_durable_delegation.py
+++ b/tests/unit/test_durable_delegation.py
@@ -32,14 +32,35 @@ def test_delegate_task_creates_one_durable_task_and_item(tmp_path: Path) -> None
         "coordination_mode": "join",
         "tool_call_id": "call-1",
     }
-    assert list_run_items(run_uid=run["run_uid"], db_name=database) == [
-        {
-            "id": f"item_agent_task_{task['task_uid']}",
-            "taskId": task["task_uid"],
-            "type": "agent_task",
-            "status": "in_progress",
-            "payload": {"agent": "researcher", "task": "核验实验设置", "summary": "已加入任务队列"},
-            "createdAt": list_run_items(run_uid=run["run_uid"], db_name=database)[0]["createdAt"],
-            "updatedAt": list_run_items(run_uid=run["run_uid"], db_name=database)[0]["updatedAt"],
-        }
-    ]
+    # The item projection carries the human-readable display name for the UI.
+    assert list_run_items(run_uid=run["run_uid"], db_name=database)[0]["payload"] == {
+        "agent": "检索研究员",
+        "task": "核验实验设置",
+        "summary": "已加入任务队列",
+    }
+
+
+def test_delegate_task_persists_context_note(tmp_path: Path) -> None:
+    database = str(tmp_path / "delegation-note.sqlite")
+    run, _ = create_run(
+        project_uid="project-1",
+        session_uid="session-1",
+        user_uuid="user-1",
+        client_request_id="request-2",
+        prompt="核验论文",
+        db_name=database,
+    )
+    task, _ = submit_delegated_agent_task(
+        run_uid=run["run_uid"],
+        tool_call_id="call-2",
+        role="researcher",
+        description="检索方差学习策略",
+        context_note="用户原问题:对比两篇论文的训练目标。已确认:DDPM 固定方差。",
+        db_name=database,
+    )
+
+    persisted = get_agent_task(task_uid=task["task_uid"], db_name=database)
+    assert persisted is not None
+    assert persisted["input"]["context_note"] == (
+        "用户原问题:对比两篇论文的训练目标。已确认:DDPM 固定方差。"
+    )

--- a/tests/unit/test_paper_tools.py
+++ b/tests/unit/test_paper_tools.py
@@ -39,6 +39,7 @@ def test_builtin_subagent_definitions_load_with_paper_capability() -> None:
     assert "paper_pack" in definitions["researcher"].capability_ids
     for definition in definitions.values():
         assert len(definition.system_prompt) > 200
+        assert definition.display_name, f"{definition.name} needs a display_name"
 
 
 def test_get_paper_citations_rejects_unknown_direction() -> None:


### PR DESCRIPTION
## 背景

对标 [openai/codex](https://github.com/openai/codex) 多智能体实现(`core/src/agent/`,源码对比报告见会话记录)后落地的四项增强。

## 变更

### 1. 委派上下文快照(对标 fork-lite)
Codex 子代理可 fork 父线程上下文;我们的子代理此前只拿 objective。现在 `delegate_task` 新增 `context_note`(≤4000 字):Leader 传入用户原问题与已有结论,随任务持久化并在子代理 prompt 中以 `[背景上下文]` 注入。委派中间件的系统指引同步教 Leader 何时传递。

### 2. 硬 token 预算(对标 RolloutBudget)
Codex 用运行时加权 token 上限截停;我们此前只有提示词软预算。新增 `TokenBudgetMiddleware`(`agent/middlewares/budget.py`):按线程累计 provider 上报的 `usage_metadata.total_tokens`,超限后下一次模型调用**去工具 + tool_choice=none + 注入交付指令**,强制"基于已有发现交付"而非循环到失败。子代理默认 150k(`PAPERSAGE_SUBAGENT_TOKEN_BUDGET` 可覆盖),经 `AgentRuntimeOptions.max_turn_tokens` 接线,仅子代理会话启用。

### 3. 按角色分档模型(对标 spawn_agent model override)
Codex 子代理可覆盖 model/reasoning_effort(awaiter 用 low)。接通已有但未使用的 `SubAgentDefinition.model` 字段:`_model_for_user(preferred_model=definition.model)`,角色未声明时回落用户配置。现在任一 agent.md 加 `model: xxx` 即生效。

### 4. 具名身份(对标 agent_names 昵称)
`agent.md` 新增 `display_name`(检索研究员/审阅研究员/写作研究员),loader 解析,委派 item 事件的 `payload.agent` 直接携带——前端活动时间线(`AgentHeader`)零改动即显示中文名。

## 测试
- 新增 `test_budget_middleware.py` 4 例(用量累计、限内透传、超限去工具+注入、非法上限)
- `test_durable_delegation.py` 更新显示名断言 + 新增 context_note 持久化用例
- `test_paper_tools.py` 增加 display_name 存在性断言
