### PR TITLE
fix(agent): propagate mid-stream model failures instead of leaking them into answers

### DIFF
--- a/agent/middlewares/builder.py
+++ b/agent/middlewares/builder.py
@@ -62,7 +62,10 @@ def build_middleware_list(
             initial_delay=1.0,
             max_delay=60.0,
             jitter=True,
-            on_failure="raise",
+            # Valid values are "error" (re-raise) or a callable; anything else
+            # silently converts the exception into an AIMessage, which the
+            # stream then renders as answer text (seen live on 2026-08-17).
+            on_failure="error",
         )
     )
 

--- a/tests/unit/test_model_failure_propagation.py
+++ b/tests/unit/test_model_failure_propagation.py
@@ -1,0 +1,80 @@
+"""Mid-stream model failures must propagate instead of becoming answer text.
+
+Regression guard for the 2026-08-17 incident: an invalid ``on_failure`` value
+made ``ModelRetryMiddleware`` format the exception into an ``AIMessage``, which
+the messages stream then rendered as answer text (run completed with the
+provider error glued into the reply).
+"""
+
+from typing import Any, Iterator
+
+import pytest
+from langchain.agents import create_agent
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_core.tools import tool
+
+from agent.middlewares.builder import build_middleware_list
+
+
+class _MidStreamBoomModel(BaseChatModel):
+    """Streams a tool call first, then raises mid-stream on the next turn."""
+
+    calls: int = 0
+
+    @property
+    def _llm_type(self) -> str:
+        return "mid-stream-boom"
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> BaseChatModel:
+        return self
+
+    def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any) -> ChatResult:
+        return ChatResult(generations=[ChatGenerationChunk(message=AIMessage(content="partial"))])
+
+    def _stream(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any) -> Iterator[ChatGenerationChunk]:
+        object.__setattr__(self, "calls", self.calls + 1)
+        if self.calls >= 2:
+            yield ChatGenerationChunk(message=AIMessageChunk(content="正在整理后续内容。"))
+            raise ValueError("boom mid-stream 400")
+        yield ChatGenerationChunk(message=AIMessageChunk(content="先检查一下"))
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(content="", tool_calls=[{"name": "probe", "args": {}, "id": "c1", "type": "tool_call"}])
+        )
+
+
+@tool
+def probe() -> str:
+    """Probe."""
+    return "ok"
+
+
+def _collect_deltas(agent: Any) -> Iterator[str]:
+    for part in agent.stream(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        config={"configurable": {"thread_id": "t"}},
+        stream_mode=["messages", "values"],
+        version="v2",
+    ):
+        if not isinstance(part, dict) or part.get("type") != "messages":
+            continue
+        data = part.get("data")
+        chunk = data[0] if isinstance(data, tuple) and data else None
+        text = getattr(chunk, "content", "") if chunk is not None else ""
+        if isinstance(text, str) and text:
+            yield text
+
+
+def test_mid_stream_failure_propagates_instead_of_leaking_into_answer() -> None:
+    middleware = build_middleware_list(
+        model=_MidStreamBoomModel(),
+        profile=None,
+        deps=None,
+        enable_tool_selector=False,
+    )
+    agent = create_agent(model=_MidStreamBoomModel(), tools=[probe], system_prompt="t", middleware=middleware)
+    deltas: list[str] = []
+    with pytest.raises(ValueError, match="boom mid-stream"):
+        deltas.extend(_collect_deltas(agent))
+    assert not any("Model call failed" in delta for delta in deltas)


### PR DESCRIPTION
## 背景

线上复现(2026-08-17 00:46,run_0982517125):MiniMax 在流式输出中途返回 400 (2013),异常文本 "Model call failed after 1 attempt with BadRequestError…" 被拼接进最终答案并随 run.completed 落库,run 状态却是 completed。

## 根因

`agent/middlewares/builder.py` 传给 `ModelRetryMiddleware` 的 `on_failure="raise"` 是无效值——该中间件合法值仅为 `"error"`(重抛)或可调用对象;其余任何值走默认分支,把异常**格式化为 AIMessage 返回**,随后被 messages 流当正文渲染。已用可复现脚本(生产同构中间件栈 + 中途抛错的流式假模型)二分定位到 `ModelRetryMiddleware` 单独即可复现。

## 修复

`on_failure="raise"` → `on_failure="error"`。异常正确向上传播,turn 以标准失败路径结束(用户看到可重试的失败提示),不再污染答案。

## 测试

新增 `test_model_failure_propagation.py`:生产同构栈下中途抛错 → 断言异常传播且流内无 "Model call failed" 文本。连同 turn_engine/session_factory 共 23 passed。