### PR TITLE
fix(web): readable tool rows in the assistant timeline with expandable detail

### DIFF
--- a/agent/application/run_timeline.py
+++ b/agent/application/run_timeline.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 from typing import Any
 
 _MAX_TEXT_LENGTH = 600
+_MAX_LABEL_ARG_LENGTH = 72
 _SENSITIVE_KEYS = {"api_key", "authorization", "password", "secret", "token"}
+# Ordered by how descriptive each key typically is for a tool-row label.
+_LABEL_ARG_KEYS = (
+    "query",
+    "question",
+    "skill_name",
+    "prompt",
+    "task",
+    "description",
+    "url",
+    "title",
+    "search",
+    "doc_name",
+    "name",
+    "text",
+)
 
 
 def project_runtime_item_event(event: dict[str, Any]) -> dict[str, Any] | None:
@@ -72,8 +88,17 @@ def project_runtime_item_event(event: dict[str, Any]) -> dict[str, Any] | None:
         payload["plan"] = _safe_value(
             {"goal": arguments.get("goal"), "steps": arguments.get("steps") or []}
         )
+    else:
+        # Row label and expandable detail: the label must stay a short
+        # "tool + key argument" line; the raw result text is for the
+        # expanded body, never the collapsed row title.
+        payload["label"] = _tool_label(tool_name, arguments)
+        if arguments:
+            payload["arguments"] = _safe_value(arguments)
     terminal = performative == "tool_result"
     failed = str(metadata.get("status") or "").lower() in {"error", "failed"}
+    if terminal:
+        payload["result"] = payload["summary"]
     return _item_event(
         item_uid=f"item_{item_type}_{task_uid or action_id}",
         item_type=item_type,
@@ -115,6 +140,20 @@ def _item_event(
 def _safe_text(value: Any) -> str:
     text = " ".join(str(value or "").split())
     return text[:_MAX_TEXT_LENGTH]
+
+
+def _tool_label(tool_name: str, arguments: dict[str, Any]) -> str:
+    """One short row label: tool name plus its most descriptive argument."""
+    candidate_keys = [key for key in _LABEL_ARG_KEYS if key in arguments]
+    candidate_keys.extend(
+        key for key in arguments if key not in candidate_keys and str(key).lower() not in _SENSITIVE_KEYS
+    )
+    for key in candidate_keys:
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            snippet = _safe_text(value)[:_MAX_LABEL_ARG_LENGTH]
+            return f'{tool_name} "{snippet}"'
+    return tool_name
 
 
 def _safe_value(value: Any) -> Any:

--- a/tests/unit/test_run_timeline.py
+++ b/tests/unit/test_run_timeline.py
@@ -3,10 +3,10 @@ from agent.application.run_timeline import project_runtime_item_event
 
 def test_projects_tool_lifecycle_as_a_versioned_item() -> None:
     started = project_runtime_item_event(
-        {"performative": "tool_call", "metadata": {"tool_name": "search_document", "tool_call_id": "call-1"}}
+        {"performative": "tool_call", "metadata": {"tool_name": "search_document", "tool_call_id": "call-1", "arguments": {"query": "DDPM noise schedule"}}}
     )
     completed = project_runtime_item_event(
-        {"performative": "tool_result", "metadata": {"tool_name": "search_document", "tool_call_id": "call-1", "status": "success", "summary": "找到 3 条资料"}}
+        {"performative": "tool_result", "metadata": {"tool_name": "search_document", "tool_call_id": "call-1", "status": "success", "summary": "找到 3 条资料", "arguments": {"query": "DDPM noise schedule"}}}
     )
 
     assert started == {
@@ -15,12 +15,42 @@ def test_projects_tool_lifecycle_as_a_versioned_item() -> None:
         "task_uid": None,
         "status": "in_progress",
         "event_type": "item.created",
-        "payload": {"summary": "", "toolName": "search_document", "durationMs": None},
+        "payload": {
+            "summary": "",
+            "toolName": "search_document",
+            "durationMs": None,
+            "label": 'search_document "DDPM noise schedule"',
+            "arguments": {"query": "DDPM noise schedule"},
+        },
     }
     assert completed is not None
     assert completed["item_uid"] == started["item_uid"]
     assert completed["event_type"] == "item.completed"
     assert completed["payload"]["summary"] == "找到 3 条资料"
+    assert completed["payload"]["result"] == "找到 3 条资料"
+    # Row label stays the tool + argument line even after the result lands.
+    assert completed["payload"]["label"] == 'search_document "DDPM noise schedule"'
+
+
+def test_tool_label_prefers_descriptive_arguments_and_drops_secrets() -> None:
+    plain = project_runtime_item_event(
+        {"performative": "tool_call", "metadata": {"tool_name": "list_document", "tool_call_id": "call-2", "arguments": {}}}
+    )
+    secret = project_runtime_item_event(
+        {"performative": "tool_call", "metadata": {"tool_name": "web_search", "tool_call_id": "call-3", "arguments": {"query": "x", "api_key": "sk-123"}}}
+    )
+    long_query = "超长" * 100
+
+    assert plain["payload"]["label"] == "list_document"
+    assert "arguments" not in plain["payload"]
+    assert secret["payload"]["label"] == 'web_search "x"'
+    assert "api_key" not in secret["payload"]["arguments"]
+
+    truncated = project_runtime_item_event(
+        {"performative": "tool_call", "metadata": {"tool_name": "search_document", "tool_call_id": "call-4", "arguments": {"query": long_query}}}
+    )
+    assert truncated["payload"]["label"].startswith('search_document "超长')
+    assert len(truncated["payload"]["label"]) < len(f'search_document "{long_query}"')
 
 
 def test_projects_text_and_reasoning_parts_as_distinct_item_deltas() -> None:

--- a/web/src/components/assistant-run-timeline.tsx
+++ b/web/src/components/assistant-run-timeline.tsx
@@ -3,13 +3,22 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from "@/components/ai-elements/reasoning";
-import { Tool, ToolHeader } from "@/components/ai-elements/tool";
+import { Tool, ToolContent, ToolHeader, ToolInput, ToolOutput } from "@/components/ai-elements/tool";
 import type { LiveRun, RenderedMessagePart } from "@/lib/live-run";
 import { cn } from "@/lib/utils";
 
 export type AssistantTimelineStep =
   | { kind: "reasoning"; id: string; text: string }
-  | { kind: "tool"; id: string; label: string; status: string; web: boolean }
+  | {
+      kind: "tool";
+      id: string;
+      toolName: string;
+      label: string;
+      status: string;
+      web: boolean;
+      args?: Record<string, unknown>;
+      result?: string;
+    }
   | { kind: "task"; id: string; label: string; status: string };
 
 function isWebTool(name: string): boolean {
@@ -20,6 +29,12 @@ function toolState(status: string): "input-available" | "output-available" | "ou
   if (status === "in_progress") return "input-available";
   if (status === "failed") return "output-error";
   return "output-available";
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 /**
@@ -56,9 +71,15 @@ export function buildLiveTimeline(run: LiveRun): AssistantTimelineStep[] {
         upsert({
           kind: "tool",
           id: item.id,
-          label: String(payload.summary ?? toolName),
+          toolName,
+          // The collapsed row must never show the raw tool result; the label
+          // from the backend is "tool + key argument" and the result text
+          // only appears inside the expanded body.
+          label: String(payload.label ?? toolName),
           status: item.status,
           web: isWebTool(toolName),
+          args: record(payload.arguments),
+          result: typeof payload.result === "string" ? payload.result : undefined,
         });
       }
       // agent_task stays out of the live timeline: the run-activity panel
@@ -91,17 +112,32 @@ export function buildTraceTimeline(
     .filter((part): part is Extract<RenderedMessagePart, { type: "reasoning" }> => part.type === "reasoning")
     .map((part) => ({ kind: "reasoning" as const, id: part.id, text: part.text }));
   const activity: AssistantTimelineStep[] = [];
+  const toolSteps = new Map<string, Extract<AssistantTimelineStep, { kind: "tool" }>>();
   trace.forEach((entry, index) => {
     const performative = String(entry.performative ?? entry.type ?? "");
+    const metadata = record(entry.metadata) ?? {};
+    const arguments_ = record(metadata.arguments) ?? {};
+    const toolName = String(
+      entry.tool_name ?? metadata.tool_name ?? entry.receiver ?? entry.name ?? "工具调用",
+    );
     if (performative === "tool_call" || performative === "skill_activate") {
-      const toolName = String(entry.tool_name ?? entry.toolName ?? entry.name ?? entry.summary ?? "工具调用");
-      activity.push({
+      const step: Extract<AssistantTimelineStep, { kind: "tool" }> = {
         kind: "tool",
         id: `trace-${index}`,
-        label: String(entry.summary ?? toolName),
+        toolName,
+        label: String(metadata.label ?? entry.summary ?? toolName),
         status: "completed",
         web: isWebTool(toolName),
-      });
+        args: Object.keys(arguments_).length ? arguments_ : undefined,
+      };
+      activity.push(step);
+      const callId = String(metadata.tool_call_id ?? "");
+      if (callId) toolSteps.set(callId, step);
+    } else if (performative === "tool_result") {
+      const callId = String(metadata.tool_call_id ?? "");
+      const step = callId ? toolSteps.get(callId) : undefined;
+      const result = String(entry.content ?? "");
+      if (step && result) step.result = result;
     } else if (performative === "delegate_task") {
       activity.push({
         kind: "task",
@@ -143,14 +179,36 @@ export function AssistantTimeline({
             </Reasoning>
           );
         }
+        if (step.kind === "task") {
+          return (
+            <Tool key={step.id}>
+              <ToolHeader
+                title={step.label}
+                type="dynamic-tool"
+                state={toolState(step.status)}
+                toolName="委派任务"
+              />
+            </Tool>
+          );
+        }
+        const failed = step.status === "failed";
         return (
           <Tool key={step.id}>
             <ToolHeader
               title={step.label}
               type="dynamic-tool"
               state={toolState(step.status)}
-              toolName={step.kind === "task" ? "委派任务" : "工具调用"}
+              toolName={step.toolName}
             />
+            <ToolContent>
+              {step.args && <ToolInput input={step.args} />}
+              {(step.result || failed) && (
+                <ToolOutput
+                  output={failed ? undefined : step.result}
+                  errorText={failed ? (step.result ?? "工具执行失败") : undefined}
+                />
+              )}
+            </ToolContent>
           </Tool>
         );
       })}

--- a/web/src/lib/live-run.test.ts
+++ b/web/src/lib/live-run.test.ts
@@ -53,7 +53,18 @@ function toolEvent(sequence: number, status: string): AgentEvent {
       id: "item-tool-1",
       type: "tool_call",
       status,
-      payload: { toolName: "search_document", summary: "检索项目资料" },
+      payload: status === "completed"
+        ? {
+            toolName: "search_document",
+            label: "search_document \"DDPM noise schedule\"",
+            arguments: { query: "DDPM noise schedule" },
+            result: "{\"evidences\": []}",
+          }
+        : {
+            toolName: "search_document",
+            label: "search_document \"DDPM noise schedule\"",
+            arguments: { query: "DDPM noise schedule" },
+          },
     },
   }
 }
@@ -143,7 +154,31 @@ describe("reduceLiveRun", () => {
 
     expect(steps.map((step) => step.kind)).toEqual(["reasoning", "tool", "reasoning"])
     expect(steps[0]).toMatchObject({ id: "reasoning:reasoning-0", text: "先定位" })
-    expect(steps[1]).toMatchObject({ kind: "tool", label: "检索项目资料", status: "completed" })
+    expect(steps[1]).toMatchObject({
+      kind: "tool",
+      toolName: "search_document",
+      label: "search_document \"DDPM noise schedule\"",
+      status: "completed",
+      args: { query: "DDPM noise schedule" },
+      result: "{\"evidences\": []}",
+    })
     expect(steps[2]).toMatchObject({ id: "reasoning:reasoning-1", text: "再综合" })
+  })
+
+  it("falls back to the tool name when no label payload exists", () => {
+    let run = createLiveRun()
+    run = reduceLiveRun(run, {
+      ...event(1, "item.created"),
+      version: 2,
+      item: {
+        id: "item-tool-legacy",
+        type: "tool_call",
+        status: "in_progress",
+        payload: { toolName: "list_document", summary: "{\"count\": 3}" },
+      },
+    })
+
+    const steps = buildLiveTimeline(run)
+    expect(steps[0]).toMatchObject({ kind: "tool", toolName: "list_document", label: "list_document" })
   })
 })


### PR DESCRIPTION
## 背景

用户反馈(2026-08-17):时间线里工具调用"太丑"、"点开后没内容"。

## 根因

1. 折叠行标题取 `payload.summary`,而工具完成事件会用**结果原文**(最长 600 字符、压扁的 JSON)覆盖它 → 一行标题变成 `{"evidences": [{"project_uid": …` 长串。
2. `<Tool>` 只渲染了 `ToolHeader`,从未渲染 `ToolContent` → 展开永远空白。

## 修复

**后端(run_timeline.py)**:tool_call 项 payload 增加
- `label`:`工具名 "关键参数"`(按 query/skill_name/url 等常见键取最具描述性的参数,截断 72 字符,敏感键不进标签);
- `arguments`:`_safe_value` 清洗后的完整参数(供展开显示);
- 完成时附 `result`(结果原文,只进展开区)。

**前端(assistant-run-timeline.tsx)**:
- 行标题用 `label`(旧数据回退工具名,不再回退 summary);
- Header 显示真实工具名;展开渲染 `ToolInput`(参数)+ `ToolOutput`(结果;失败态红色错误样式);
- `buildTraceTimeline` 从 trace 的 metadata 读工具名/参数,修复持久化回放里所有行都叫"工具调用"的问题,并按 tool_call_id 合并 call/result 两阶段。

## 测试

- 后端 `test_run_timeline.py`:label 构造、敏感键剔除、截断、结果落 payload;6 passed。
- 前端 `live-run.test.ts`:label/args/result 映射与旧数据回退;7 passed。`tsc --noEmit` 通过。