### PR TITLE
perf(desktop): defer lancedb, fastembed and langchain_community out of startup

### DIFF
--- a/agent/adapters/lancedb/rag_index.py
+++ b/agent/adapters/lancedb/rag_index.py
@@ -8,9 +8,23 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-import lancedb
-import pyarrow as pa
-from lancedb.index import FTS
+# LanceDB drags a full OpenAPI client suite and pyarrow into the process;
+# both are deferred so API startup does not pay for them (cold starts on the
+# desktop bundle measured seconds for this import alone).
+lancedb: Any = None
+pa: Any = None
+FTS: Any = None
+
+
+def _ensure_lance_imports() -> None:
+    global lancedb, pa, FTS
+    if lancedb is None:
+        import lancedb as _lancedb
+        import pyarrow as _pa
+        from lancedb.index import FTS as _FTS
+
+        lancedb, pa, FTS = _lancedb, _pa, _FTS
+
 
 _LOCK = threading.RLock()
 _TABLE_PREFIX = "rag_chunks"
@@ -27,7 +41,8 @@ def _table_name(settings_signature: str, vector_size: int) -> str:
     return f"{_TABLE_PREFIX}_{safe_signature}_{vector_size}"
 
 
-def _schema(vector_size: int) -> pa.Schema:
+def _schema(vector_size: int) -> Any:
+    _ensure_lance_imports()
     return pa.schema(
         [
             pa.field("chunk_id", pa.string(), nullable=False),
@@ -50,6 +65,7 @@ def _schema(vector_size: int) -> pa.Schema:
 
 
 def _connect() -> Any:
+    _ensure_lance_imports()
     path = _database_path()
     path.mkdir(parents=True, exist_ok=True)
     return lancedb.connect(path)
@@ -88,6 +104,7 @@ def document_index_exists(
     index_version: str,
     vector_size: int | None = None,
 ) -> bool:
+    _ensure_lance_imports()
     settings_signature = index_version.split(":", 1)[0]
     with _LOCK:
         database = _connect()
@@ -121,6 +138,7 @@ def publish_document_index(
     embeddings: list[list[float]],
 ) -> int:
     """Publish versioned rows; SQLite ready state controls external visibility."""
+    _ensure_lance_imports()
     if not chunks or len(chunks) != len(metadatas) or len(chunks) != len(embeddings):
         raise ValueError("LanceDB publish requires aligned non-empty chunks and vectors")
     vector_size = len(embeddings[0])
@@ -219,6 +237,7 @@ def search_published_chunks(
     score, not a provider-specific hybrid score, so retrieval traces remain
     explainable across LanceDB releases.
     """
+    _ensure_lance_imports()
     if not ready_versions or not query_vector:
         return []
     grouped: dict[str, list[tuple[str, str]]] = defaultdict(list)

--- a/agent/embedding_provider.py
+++ b/agent/embedding_provider.py
@@ -1,14 +1,20 @@
 """Local semantic embedding model provider."""
 
 from functools import lru_cache
-
-from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+from typing import TYPE_CHECKING
 
 from .settings import load_agent_settings
 
+if TYPE_CHECKING:
+    from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+
 
 @lru_cache(maxsize=2)
-def get_embedding_model() -> FastEmbedEmbeddings:
+def get_embedding_model() -> "FastEmbedEmbeddings":
+    # langchain_community (and through it fastembed + onnxruntime) costs
+    # seconds to import; defer it until an embedding is actually requested.
+    from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+
     settings = load_agent_settings()
     return FastEmbedEmbeddings(
         model_name=settings.local_embedding_model,

--- a/agent/rag/fastembed_runtime.py
+++ b/agent/rag/fastembed_runtime.py
@@ -2,8 +2,11 @@
 
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+if TYPE_CHECKING:
+    from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
+
 
 
 def _is_missing_model_error(exc: BaseException) -> bool:
@@ -16,7 +19,9 @@ def _model_cache_dir(cache_dir: str, model_name: str) -> Path:
     return Path(cache_dir) / f"models--{org}--{name}"
 
 
-def build_fastembed_embeddings(*, model_name: str, cache_dir: str) -> FastEmbedEmbeddings:
+def build_fastembed_embeddings(*, model_name: str, cache_dir: str) -> "FastEmbedEmbeddings":
+    # Deferred for startup cost; see agent/embedding_provider.py.
+    from langchain_community.embeddings.fastembed import FastEmbedEmbeddings
     try:
         return FastEmbedEmbeddings(model_name=model_name, cache_dir=cache_dir)
     except Exception as exc:

--- a/agent/tools/web_search.py
+++ b/agent/tools/web_search.py
@@ -6,7 +6,6 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
-from langchain_community.tools import DuckDuckGoSearchRun
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
@@ -239,6 +238,9 @@ def _ensure_web_search_clients() -> list[tuple[str, Any]]:
                 logger.info("tool.search_web provider fallback initialized: native_duckduckgo_search")
             else:
                 try:
+                    # langchain_community import costs seconds; pay it on use only.
+                    from langchain_community.tools import DuckDuckGoSearchRun
+
                     native_client = DuckDuckGoSearchRun()
                     clients.append(("langchain_duckduckgo_search", native_client))
                     logger.info("tool.search_web provider fallback initialized: langchain_duckduckgo_search")

--- a/tests/unit/test_fastembed_runtime.py
+++ b/tests/unit/test_fastembed_runtime.py
@@ -22,7 +22,7 @@ def test_partial_download_cache_is_cleared_and_retried(monkeypatch, tmp_path):
             )
         return object()
 
-    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", fake_ctor)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", fake_ctor)
 
     result = build_fastembed_embeddings(model_name=_MODEL, cache_dir=str(cache_dir))
 
@@ -39,7 +39,7 @@ def test_unrelated_errors_are_raised_without_cache_wipe(monkeypatch, tmp_path):
     def fake_ctor(**_kwargs):
         raise Exception("CUDA execution provider failure")
 
-    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", fake_ctor)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", fake_ctor)
 
     with pytest.raises(Exception, match="CUDA"):
         build_fastembed_embeddings(model_name=_MODEL, cache_dir=str(cache_dir))

--- a/tests/unit/test_rag_hybrid.py
+++ b/tests/unit/test_rag_hybrid.py
@@ -33,9 +33,8 @@ def _replace_embedding_downloads(monkeypatch: pytest.MonkeyPatch) -> None:
         def embed_query(self, query: str) -> list[float]:
             return [float(len(query))] * 384
 
-    from agent.rag import fastembed_runtime
 
-    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", _FakeEmbeddings)
 
 
 class TestReciprocalRankFusion:
@@ -458,9 +457,8 @@ def test_project_retriever_reuses_persisted_doc_indexes(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    from agent.rag import fastembed_runtime
 
-    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [
@@ -529,9 +527,8 @@ def test_project_retriever_returns_empty_for_low_relevance(monkeypatch, tmp_path
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    from agent.rag import fastembed_runtime
 
-    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [
@@ -588,9 +585,8 @@ def test_project_retriever_uses_similarity_score(monkeypatch, tmp_path):
     )
 
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "project_indexes"))
-    from agent.rag import fastembed_runtime
 
-    monkeypatch.setattr(fastembed_runtime, "FastEmbedEmbeddings", _FakeEmbeddings)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", _FakeEmbeddings)
     monkeypatch.setattr(hybrid_module, "load_agent_settings", lambda: fake_settings)
 
     documents = [

--- a/tests/unit/test_rag_ingestion.py
+++ b/tests/unit/test_rag_ingestion.py
@@ -360,7 +360,7 @@ def test_ingestion_reports_real_embedding_batches_and_publishes_atomically(
         def embed_query(self, _query):
             return [1.0, 10.0]
 
-    monkeypatch.setattr("agent.rag.fastembed_runtime.FastEmbedEmbeddings", _Embeddings)
+    monkeypatch.setattr("langchain_community.embeddings.fastembed.FastEmbedEmbeddings", _Embeddings)
     monkeypatch.setenv("AGENT_PROJECT_INDEX_CACHE_DIR", str(tmp_path / "indexes"))
     monkeypatch.setenv("LOCAL_RAG_CHUNK_SIZE", "12")
     monkeypatch.setenv("LOCAL_RAG_CHUNK_OVERLAP", "0")

--- a/tests/unit/test_startup_import_budget.py
+++ b/tests/unit/test_startup_import_budget.py
@@ -1,0 +1,47 @@
+"""Guard the API startup import budget.
+
+Importing api.main used to pull lancedb, pyarrow, fastembed, onnxruntime and
+langchain_community into every desktop launch (seconds of cold-start). Those
+stacks are deferred to first use; this test blocks them so a new eager import
+fails loudly instead of silently re-inflating startup.
+"""
+
+import subprocess
+import sys
+
+BLOCKED_PREFIXES = (
+    "lancedb",
+    "pyarrow",
+    "fastembed",
+    "onnxruntime",
+    "langchain_community",
+)
+
+_PROBE = """
+import sys
+
+blocked = {prefixes!r}
+
+class _StartupBudgetGuard:
+    def find_module(self, name, path=None):
+        if name.split(".")[0] in blocked:
+            raise ImportError(
+                f"api.main startup must not import {{name}}; defer it to first use"
+            )
+        return None
+
+sys.meta_path.insert(0, _StartupBudgetGuard())
+import api.main
+print("STARTUP_IMPORTS_OK")
+"""
+
+
+def test_api_startup_does_not_import_rag_and_embedding_stacks() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(prefixes=BLOCKED_PREFIXES)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "STARTUP_IMPORTS_OK" in result.stdout


### PR DESCRIPTION
## 问题

启动慢的实测定位:api.main 导入链拉起 **3303 个模块、7.8s(dev)**;打包后端热启动实测 5.4s(exe→端口就绪),大头全在导入——lancedb 连带整套 lance OpenAPI 客户端 + pyarrow、embedding provider 连带 fastembed + onnxruntime、web_search 工具连带 langchain_community,全部在**启动期**导入,而它们只在第一次 RAG/嵌入/搜索时才真正用到。

## 改动

- `rag_index`:lancedb/pyarrow/FTS 改为惰性绑定,三个公共入口 ensure
- `embedding_provider` / `fastembed_runtime`:fastembed 延迟到首次取模型(TYPE_CHECKING 保留类型)
- `web_search`:DuckDuckGo 工具延迟到调用点
- **导入预算守卫测试**:子进程装 meta_path 拦截器,api.main 导入期间出现这些包即失败——防回归
- 相应测试改为 patch 源头模块(`langchain_community.embeddings.fastembed`)

## 验证

- 导入图 7.82s → **4.89s(−38%)**,lancedb/pyarrow/fastembed/langchain_community/onnxruntime 全部退出启动集(守卫脚本实测)
- 后端全量 **366 passed**;ruff 干净
- 用户机器上打包 exe 热启动基线 5.4s(改动前)——合并发版后复测预期 ~3.5s,冷启动受益更大