### PR TITLE
fix(agent): sanitize replayed history at the provider boundary

### DIFF
--- a/agent/middlewares/builder.py
+++ b/agent/middlewares/builder.py
@@ -19,6 +19,7 @@ from .model_output_validation import (
     model_output_validation_middleware,
 )
 from .plan import plan_middleware
+from .provider_history_hygiene import provider_history_hygiene_middleware
 from .steering_input import steering_input_middleware
 from .tool_selector import build_tool_selector_middleware
 from .trace import TraceMiddleware
@@ -71,6 +72,9 @@ def build_middleware_list(
 
     middleware_list.append(turn_context_middleware)
     middleware_list.append(steering_input_middleware)
+    # Legacy threads replay provider-error artifacts and consecutive human
+    # turns; strict providers (e.g. MiniMax) answer those with 400 forever.
+    middleware_list.append(provider_history_hygiene_middleware)
 
     if _is_enabled(profile, "subagent"):
         if deps is None:

--- a/agent/middlewares/provider_history_hygiene.py
+++ b/agent/middlewares/provider_history_hygiene.py
@@ -1,0 +1,67 @@
+"""Provider-boundary hygiene for replayed conversation history.
+
+Legacy threads (before the 2026-08-17 on_failure fix) carry assistant
+messages whose content is a provider error string, and follow-up delivery
+can leave consecutive human messages. Strict OpenAI-compatible providers
+reject both with opaque 400 "invalid params" errors that then repeat on
+every turn because the poisoned history replays forever. This middleware
+cleans what is SENT to the provider on each call; stored state is not
+rewritten.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
+
+# The 2026-08-17 retry-middleware incident formatted exceptions into
+# AIMessages with this exact prefix; they carry no model output.
+_FAILURE_ARTIFACT_PREFIX = "Model call failed after"
+
+
+def sanitize_messages_for_provider(messages: list[Any]) -> list[Any]:
+    """Drop failure artifacts and merge consecutive same-role human turns."""
+    cleaned: list[Any] = []
+    for message in messages:
+        if getattr(message, "type", "") == "ai" and str(
+            getattr(message, "content", "") or ""
+        ).startswith(_FAILURE_ARTIFACT_PREFIX):
+            continue
+        cleaned.append(message)
+    merged: list[Any] = []
+    for message in cleaned:
+        previous = merged[-1] if merged else None
+        if (
+            getattr(message, "type", "") == "human"
+            and getattr(previous, "type", "") == "human"
+        ):
+            merged[-1] = message.__class__(
+                content=f"{previous.content}\n\n{message.content}",
+                **(
+                    {"name": previous.name}
+                    if getattr(previous, "name", None)
+                    else {}
+                ),
+            )
+            continue
+        merged.append(message)
+    return merged
+
+
+class ProviderHistoryHygieneMiddleware(AgentMiddleware):
+    """Strip error artifacts and role runs from each outgoing model request."""
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        sanitized = sanitize_messages_for_provider(list(request.messages))
+        if len(sanitized) != len(request.messages):
+            request.messages[:] = sanitized
+        return handler(request)
+
+
+provider_history_hygiene_middleware = ProviderHistoryHygieneMiddleware()

--- a/tests/unit/test_provider_history_hygiene.py
+++ b/tests/unit/test_provider_history_hygiene.py
@@ -1,0 +1,56 @@
+"""Provider-boundary history hygiene."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from agent.middlewares.builder import build_middleware_list
+from agent.middlewares.provider_history_hygiene import (
+    ProviderHistoryHygieneMiddleware,
+    sanitize_messages_for_provider,
+)
+
+
+def test_failure_artifacts_are_dropped_and_normal_history_kept() -> None:
+    sanitized = sanitize_messages_for_provider(
+        [
+            HumanMessage(content="你好"),
+            AIMessage(content="Model call failed after 1 attempt with BadRequestError: 400"),
+            AIMessage(content="正常的回答"),
+            HumanMessage(content="继续"),
+        ]
+    )
+
+    assert [type(m).__name__ for m in sanitized] == ["HumanMessage", "AIMessage", "HumanMessage"]
+    assert sanitized[1].content == "正常的回答"
+
+
+def test_consecutive_human_messages_merge_into_one_turn() -> None:
+    sanitized = sanitize_messages_for_provider(
+        [
+            HumanMessage(content="你好"),
+            HumanMessage(content="/new"),
+            HumanMessage(content="11"),
+        ]
+    )
+
+    assert len(sanitized) == 1
+    assert sanitized[0].content == "你好\n\n/new\n\n11"
+
+
+def test_alternating_history_passes_through_untouched() -> None:
+    messages = [
+        HumanMessage(content="第一问"),
+        AIMessage(content="第一答"),
+        ToolMessage(content="tool", tool_call_id="c1"),
+        HumanMessage(content="第二问"),
+    ]
+
+    assert sanitize_messages_for_provider(messages) == messages
+
+
+def test_hygiene_middleware_is_wired_into_the_default_stack() -> None:
+    class _FakeModel:
+        _llm_type = "fake-openai"
+
+    stack = build_middleware_list(model=_FakeModel())
+
+    assert any(isinstance(m, ProviderHistoryHygieneMiddleware) for m in stack)


### PR DESCRIPTION
## 问题(用户现场:\"Agent 运行失败\"无限循环)

backend.log 实证:MiniMax 返回 `400 invalid params (2013)`,且每次重发都失败。线程历史里躺着两条毒消息:

1. **错误文本被当成 assistant 正文**:`AIMessage(content=\"Model call failed after 1 attempt with BadRequestError: 400…\")` —— 2026-08-17 on_failure 缺陷期间写入,修复后存量仍在线程里永久重放
2. **连续 human 消息**:追问投递产生了相邻的同角色消息(`/new`、`11`)

严格校验的 provider(MiniMax)对二者都直接 400,**一次瞬时故障永久毒化会话**。

## 修复

新增 `provider_history_hygiene` 中间件,在每次模型调用的发送边界(`wrap_model_call` 原地改 request.messages):

- 丢弃 `Model call failed after` 前缀的错误残迹 AIMessage
- 合并连续 human 消息(\n\n 连接)

只净化**发出**的内容,不改写线程存档——历史证据保留,发送合规。

## 验证

4 个新用例(残迹剔除/连续合并/交替历史原样/默认栈接线);全量 **370 passed**;ruff 干净