### PR TITLE
fix(agent): drop orphaned tool turns and keep the context card after compact

### DIFF
--- a/agent/application/session_commands.py
+++ b/agent/application/session_commands.py
@@ -23,7 +23,7 @@ from ..adapters.user_settings import (
     read_base_url_for_user,
     read_model_name_for_user,
 )
-from ..context_governance import estimate_message_tokens
+from ..context_governance import build_context_usage_snapshot, estimate_message_tokens
 from ..llm_provider import build_openai_compatible_chat_model
 from ..skills.loader import discover_available_skills
 from .workspace import require_project
@@ -324,7 +324,13 @@ def _execute_compact(*, project_uid: str, session_uid: str, user_uuid: str, args
     final_messages = [
         *kept_messages,
         {"role": "user", "content": user_text},
-        {"role": "assistant", "content": confirmation},
+        {
+            "role": "assistant",
+            "content": confirmation,
+            # The composer's context card reads the newest assistant message;
+            # without a fresh snapshot the indicator disappears after compact.
+            "context_snapshot": build_context_usage_snapshot(messages=kept_messages),
+        },
     ]
     save_project_session_messages(
         session_uid=session_uid, project_uid=project_uid, uuid=user_uuid, messages=final_messages

--- a/agent/middlewares/provider_history_hygiene.py
+++ b/agent/middlewares/provider_history_hygiene.py
@@ -22,13 +22,36 @@ _FAILURE_ARTIFACT_PREFIX = "Model call failed after"
 
 
 def sanitize_messages_for_provider(messages: list[Any]) -> list[Any]:
-    """Drop failure artifacts and merge consecutive same-role human turns."""
+    """Drop failure artifacts, orphaned tool turns, and merged human runs.
+
+    A tool message is only valid when the message right before it is an ai
+    message carrying the matching tool_call_id; mid-stream failures and
+    manual history surgery both leave orphans behind, and strict providers
+    (MiniMax 2013, seen live) reject the whole request for them.
+    """
     cleaned: list[Any] = []
+    open_call_ids: set[str] = set()
     for message in messages:
-        if getattr(message, "type", "") == "ai" and str(
+        kind = getattr(message, "type", "")
+        if kind == "ai" and str(
             getattr(message, "content", "") or ""
         ).startswith(_FAILURE_ARTIFACT_PREFIX):
             continue
+        if kind == "tool":
+            call_id = str(getattr(message, "tool_call_id", "") or "")
+            if call_id not in open_call_ids:
+                continue
+            open_call_ids.discard(call_id)
+            cleaned.append(message)
+            continue
+        if kind == "ai":
+            open_call_ids = {
+                str(call.get("id") or "")
+                for call in (getattr(message, "tool_calls", None) or [])
+                if isinstance(call, dict) and str(call.get("id") or "")
+            }
+        else:
+            open_call_ids = set()
         cleaned.append(message)
     merged: list[Any] = []
     for message in cleaned:

--- a/tests/unit/test_provider_history_hygiene.py
+++ b/tests/unit/test_provider_history_hygiene.py
@@ -39,12 +39,54 @@ def test_consecutive_human_messages_merge_into_one_turn() -> None:
 def test_alternating_history_passes_through_untouched() -> None:
     messages = [
         HumanMessage(content="第一问"),
-        AIMessage(content="第一答"),
+        AIMessage(content="", tool_calls=[{"name": "search", "args": {}, "id": "c1"}]),
         ToolMessage(content="tool", tool_call_id="c1"),
+        AIMessage(content="第一答"),
         HumanMessage(content="第二问"),
     ]
 
     assert sanitize_messages_for_provider(messages) == messages
+
+
+def test_orphaned_tool_messages_are_dropped() -> None:
+    sanitized = sanitize_messages_for_provider(
+        [
+            HumanMessage(content='你好'),
+            ToolMessage(content='{}', tool_call_id='orphan-1'),
+            ToolMessage(content='{}', tool_call_id='orphan-2'),
+            HumanMessage(content='继续'),
+        ]
+    )
+
+    assert [type(m).__name__ for m in sanitized] == ['HumanMessage']
+    assert '你好' in sanitized[0].content and '继续' in sanitized[0].content
+
+
+def test_matched_tool_call_pairs_survive_including_multiples() -> None:
+    ai_with_calls = AIMessage(
+        content='',
+        tool_calls=[
+            {'name': 'search_document', 'args': {'query': 'a'}, 'id': 'call-1'},
+            {'name': 'search_document', 'args': {'query': 'b'}, 'id': 'call-2'},
+        ],
+    )
+    sanitized = sanitize_messages_for_provider(
+        [
+            HumanMessage(content='查一下'),
+            ai_with_calls,
+            ToolMessage(content='r1', tool_call_id='call-2'),
+            ToolMessage(content='r2', tool_call_id='call-1'),
+            AIMessage(content='结论'),
+        ]
+    )
+
+    assert [type(m).__name__ for m in sanitized] == [
+        'HumanMessage',
+        'AIMessage',
+        'ToolMessage',
+        'ToolMessage',
+        'AIMessage',
+    ]
 
 
 def test_hygiene_middleware_is_wired_into_the_default_stack() -> None:


### PR DESCRIPTION
## 现场(用户日志实证)

1.11.1 的 hygiene 修了错误残迹,但 MiniMax 仍 400(2013)。提取完整 LLM_INPUT 发现请求形态:`system → 4×tool → human`——**四条孤儿 tool 消息,对应带 tool_calls 的 AI 消息早已不在**(08-17 事故 era 遗留在线程 checkpointer 里),严格 provider 直接整单拒绝。
另外用户跑完 /compact 后 context 图标消失:压缩确认消息不含 `context_snapshot`,而作曲器卡片读取最新 assistant 消息的快照。

## 修复

- hygiene 以\"未决 tool_call id 集合\"追踪配对:tool 消息无匹配 call 即剔除;一次 call 的多条结果合法保留
- /compact 确认消息附带压缩后历史的全新 context_snapshot,图标即时恢复

## 验证

新增 2 用例(孤儿剔除后 human 合并、多结果配对保留);全量 **390 passed**;ruff 干净