### PR TITLE
chore(deps): ignore chromadb major bumps on the retiring legacy path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # chromadb is capped <1.0 deliberately: the legacy in-process retriever
+      # uses it only via langchain-chroma, and the whole path retires in favor
+      # of the LanceDB production chain (docs/exec-plans/tech-debt-tracker.md
+      # item b). Major bumps add risk to a dying path for zero value.
+      - dependency-name: "chromadb"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:


### PR DESCRIPTION
## 背景与问题
dependabot 反复提议 chromadb 0.x→1.x 大版本升级(#167 已关闭);该依赖仅经 langchain-chroma 服务于 legacy in-process 检索路径,pyproject 已刻意钉 <1.0.0,整条路径按技术债清单条目 b 退役中(生产走 LanceDB)。

## 改动范围
.github/dependabot.yml:UV 生态增加 chromadb semver-major 忽略;minor/patch 照常。

## 风险点
无——纯 dependabot 行为配置。

## 回滚方式
revert。

## 测试结果
YAML 语法校验;配置语义对照 dependabot 官方文档 ignore.update-types。